### PR TITLE
Bugfix/79 return videos for all categories

### DIFF
--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -43,12 +43,17 @@ settings = Settings(plugin)
 
 @plugin.route('/', name='index')
 def index():
-    return view.build_categories(settings)
+    return view.build_categories(plugin.get_storage('most_viewed_categories', TTL=60), settings)
 
 
-@plugin.route('/category/<category_code>', name='category')
-def category(category_code):
-    return view.build_category(category_code, settings)
+@plugin.route('/api_category/<category_code>', name='api_category')
+def api_category(category_code):
+    return view.build_api_category(category_code, settings)
+
+
+@plugin.route('/cached_category/<category_code>', name='cached_category')
+def cached_category(category_code):
+    return view.get_cached_category(category_code, plugin.get_storage('most_viewed_categories', TTL=60))
 
 
 # @plugin.route('/creative', name='creative')

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -1,6 +1,6 @@
 import datetime
 import dateutil.parser
-import xbmc
+from xbmcswift2 import xbmc
 import html
 import urllib.parse
 

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -4,8 +4,7 @@ import mapper
 import hof
 import utils
 
-
-def build_categories(settings):
+def build_categories(most_viewed_categories, settings):
     categories = [
         mapper.create_favorites_item(),
         mapper.create_last_viewed_item(),
@@ -13,8 +12,8 @@ def build_categories(settings):
         mapper.create_most_viewed_item(),
         mapper.create_last_chance_item(),
     ]
-    categories.extend([mapper.map_categories_item(item) for item in
-        api.categories(settings.language)])
+    categories.extend(mapper.map_categories(
+        api.categories(settings.language), settings.show_video_streams, most_viewed_categories))
     # categories.append(mapper.create_creative_item())
     categories.append(mapper.create_magazines_item())
     categories.append(mapper.create_week_item())
@@ -22,11 +21,15 @@ def build_categories(settings):
     return categories
 
 
-def build_category(category_code, settings):
+def build_api_category(category_code, settings):
     category = [mapper.map_category_item(item, category_code) for item in
             api.category(category_code, settings.language)]
 
     return category
+
+
+def get_cached_category(category_title, most_viewed_categories):
+    return most_viewed_categories[category_title]
 
 
 def build_magazines(settings):


### PR DESCRIPTION
Arte HBB TV API was returning 2 types of categories. Some with code MOST_VIEWED and other with unique code. Most of MOST_VIEWED categories was containing videos in teasers node. These categories are now supported. MOST_VIEWED categories without Teasers are ignored.