### PR TITLE
 Releasing 1.1.4 + Fetch "Magazines a-z" with arte tv api instead of hbbtv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 1.1.4
+
+- Added Live stream in root menu
+- Got "Magazines A-Z" content from Arte TV instead of HBB TV API.
+- Fixed empty categories - discrepencies with Arte TV - Bug #79
+
 # Version 1.1.3
 
 - Added Polish translation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Plugin Kodi (ex XBMC) permettant de voir les vidéos disponibles sur Arte +7
 
-For feature requests or reporting issues go [here](https://github.com/known-as-bmf/plugin.video.arteplussept/issues).
+For feature requests or reporting issues go [here](https://github.com/thomas-ernest/plugin.video.arteplussept/issues).
 
 Contributions are welcome !
 
@@ -16,7 +16,7 @@ You can either :
 
 # Manual installation
 
-Download the plugin [here](https://github.com/known-as-bmf/plugin.video.arteplussept/archive/master.zip)
+Download the plugin [here](https://github.com/thomas-ernest/plugin.video.arteplussept/archive/refs/heads/master.zip)
 
 Then follow the steps bellow depending on your system and software version
 
@@ -41,15 +41,27 @@ Then follow the steps bellow depending on your system and software version
 
 * Extract the content of the zip in the `addons` folder
 * Rename the extracted directory from `plugin.video.arteplussept-master` to `plugin.video.arteplussept`
+
+### Linux
+
+* unzip -x plugin.video.arteplussept-master.zip
+* mv plugin.video.arteplussept plugin.video.arteplussept-backup OR rm -fr plugin.video.arteplussept
+* mv plugin.video.arteplussept-master plugin.video.arteplussept
+
+##3. Enjoy
+
 * Done ! The plugin should show up in your video add-ons section.
 
 # Troubleshooting
 
-If you are having issues with the add-on, you can open a issue ticket and join your log file. The log file will contain your system user name and sometimes passwords of services you use in the software, so you may want to sanitize it beforehand. Detailed procedure [here](http://kodi.wiki/view/Log_file/Easy).
-
-You should also try installing the dependancies manually via Kodi / XBMC. The dependancies are :
+If you get an issue after a fresh manual installation, you should try
+either to restart in order to install dependencies automatically
+either to install the dependancies manually. The dependancies are :
 
 * xbmcswift2 (script.module.xbmcswift2)
 * requests (script.module.requests)
+* dateutil (script.module.dateutil)
 
 They should be in the "addon libraries" section of the official repository.
+
+If you are having issues with the add-on, you can open a issue ticket and join your log file. The log file will contain your system user name and sometimes passwords of services you use in the software, so you may want to sanitize it beforehand. Detailed procedure [here](http://kodi.wiki/view/Log_file/Easy).

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.3" provider-name="bmf">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.4" provider-name="bmf, thomas-ernest">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.xbmcswift2" version="19.0.4"/>
@@ -58,6 +58,10 @@ https://github.com/known-as-bmf/plugin.video.arteplussept
             <fanart>resources/fanart.jpg</fanart>
         </assets>
         <news>
+        v1.1.4
+        - Added Live stream in root menu
+        - Got &quote;Magazines A-Z&quote; content from Arte TV instead of HBB TV API.
+        - Fixed empty categories - discrepencies with Arte TV - Bug #79
         v1.1.3
         - Added Polish translation
         - Added My list and My history content from Arte TV profile

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+v1.1.4
+- Added Live stream in root menu
+- Got "Magazines A-Z" content from Arte TV instead of HBB TV API.
+- Fixed empty categories - discrepencies with Arte TV - Bug #79
+
+v1.1.3
+- Added Polish translation
+- Added My list and My history content from Arte TV profile
+
 v1.1.2
 - better date / locale handling &amp; prevent crash when http error
 

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -73,3 +73,7 @@ msgstr "Authentifizierungsfehler"
 msgctxt "#30021"
 msgid "Email or password missing"
 msgstr "E-Mail oder Passwort fehlen"
+
+msgctxt "#30022"
+msgid "Update your profile in settings to fetch this content"
+msgstr "Aktualisieren Sie Ihre Profil in den Einstellungen, um diesen Inhalt abzurufen"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -1,7 +1,7 @@
 # Kodi Media Center language file
 # Addon Name: Arte +7
 # Addon id: plugin.video.arteplussept
-# Addon Provider: bmf
+# Addon Provider: bmf, thomas-ernest
 msgid ""
 msgstr ""
 "MIME-Version: 1.0\n"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -73,3 +73,7 @@ msgstr ""
 msgctxt "#30021"
 msgid "Email or password missing"
 msgstr ""
+
+msgctxt "#30022"
+msgid "Update your profile in settings to fetch this content"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1,7 +1,7 @@
 # Kodi Media Center language file
 # Addon Name: Arte +7
 # Addon id: plugin.video.arteplussept
-# Addon Provider: bmf
+# Addon Provider: bmf, thomas-ernest
 msgid ""
 msgstr ""
 "MIME-Version: 1.0\n"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -73,3 +73,7 @@ msgstr "Impossible de s'authentifier"
 msgctxt "#30021"
 msgid "Email or password missing"
 msgstr "E-mail ou mot de passe manquant"
+
+msgctxt "#30022"
+msgid "Update your profile in settings to fetch this content"
+msgstr "Mettez à jour votre profil dans la configuration pour télécharger ce contenu"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -1,7 +1,7 @@
 # Kodi Media Center language file
 # Addon Name: Arte +7
 # Addon id: plugin.video.arteplussept
-# Addon Provider: bmf
+# Addon Provider: bmf, thomas-ernest
 msgid ""
 msgstr ""
 "MIME-Version: 1.0\n"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -73,3 +73,7 @@ msgstr "Impossibile autenticare"
 msgctxt "#30021"
 msgid "Email or password missing"
 msgstr "E-mail o password mancanti"
+
+msgctxt "#30022"
+msgid "Update your profile in settings to fetch this content"
+msgstr "Aggiorna il tuo profilo nelle impostazioni per recuperare questo contenuto"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -1,7 +1,7 @@
 # Kodi Media Center language file
 # Addon Name: Arte +7
 # Addon id: plugin.video.arteplussept
-# Addon Provider: bmf
+# Addon Provider: bmf, thomas-ernest
 msgid ""
 msgstr ""
 "MIME-Version: 1.0\n"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -73,3 +73,7 @@ msgstr "Nie można uwierzytelnić"
 msgctxt "#30021"
 msgid "Email or password missing"
 msgstr "Brak e-mail lub hasła"
+
+msgctxt "#30022"
+msgid "Update your profile in settings to fetch this content"
+msgstr "Zaktualizuj swój profil w ustawieniach, aby pobrać tę zawartość"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -1,7 +1,7 @@
 # Kodi Media Center language file
 # Addon Name: Arte +7
 # Addon id: plugin.video.arteplussept
-# Addon Provider: bmf
+# Addon Provider: bmf, thomas-ernest
 msgid ""
 msgstr ""
 "MIME-Version: 1.0\n"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -4,6 +4,7 @@
 #
 # plugin.video.arteplussept, Kodi add-on to watch videos from http://www.arte.tv/guide/fr/plus7/
 # Copyright (C) 2015  known-as-bmf
+# Copyright (C) 2023  thomas-ernest
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 import requests
-import xbmc
+from xbmcswift2 import xbmc
 
 import hof
 
@@ -16,7 +16,7 @@ _endpoints = {
     'categories': '/EMAC/teasers/{type}/v2/{lang}',
     'category': '/EMAC/teasers/category/v2/{category_code}/{lang}',
     'subcategory': '/OPA/v3/videos/subcategory/{sub_category_code}/page/1/limit/100/{lang}',
-    'magazines': '/OPA/v3/magazines/{lang}',
+    # 'magazines': '/OPA/v3/magazines/{lang}', # moved to arte tv api
     'collection': '/EMAC/teasers/collection/v2/{collection_id}/{lang}',
     # program details
     'video': '/OPA/v3/videos/{program_id}/{lang}',
@@ -32,6 +32,7 @@ _artetv_endpoints = {
     'token': '/sso/v3/token', # POST
     'favorites': '/sso/v3/favorites/{lang}?page={page}&limit={limit}', #GET
     'last_viewed': '/sso/v3/lastvieweds/{lang}?page={page}&limit={limit}', #GET
+    'magazines': '/sso/v3/magazines/{lang}?page={page}&limit={limit}', #GET
     'live': '/player/v2/config/{lang}/LIVE', #GET
 }
 _artetv_headers = {
@@ -65,11 +66,6 @@ def home_category(name, lang):
     return _load_json(url).get('teasers', {}).get(name, [])
 
 
-def magazines(lang):
-    url = _endpoints['magazines'].format(lang=lang)
-    return _load_json(url).get('magazines', {})
-
-
 def category(category_code, lang):
     url = _endpoints['category'].format(category_code=category_code, lang=lang)
     return _load_json(url).get('category', {})
@@ -98,6 +94,11 @@ def streams(kind, program_id, lang):
     url = _endpoints['streams'] .format(
         kind=kind, program_id=program_id, lang=lang)
     return _load_json(url).get('videoStreams', [])
+
+
+def magazines(lang):
+    url = _artetv_url + _artetv_endpoints['magazines'].format(lang=lang, page='1', limit='50')
+    return _load_json_full_url(url, _artetv_headers).get('data')
 
 
 def daily(date, lang):

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -133,6 +133,7 @@ def _load_json_personal_content(plugin, url, usr, pwd, hdrs=_artetv_headers):
 def token(plugin, username="", password=""):
     # unable to authenticate if either username or password are empty
     if not username and not password:
+        plugin.notify(msg=plugin.addon.getLocalizedString(30022), image='info')
         return None
     # inform that setings are incomplete
     if not username or not password:


### PR DESCRIPTION
No functional change. Only download data from Arte TV API instead of HBB TV for section "magazines A-Z".