### PR TITLE
Manage favorites in Arte Profile from Kodi

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -81,3 +81,27 @@ msgstr "E-Mail oder Passwort fehlen"
 msgctxt "#30022"
 msgid "Update your profile in settings to fetch this content"
 msgstr "Aktualisieren Sie Ihre Profil in den Einstellungen, um diesen Inhalt abzurufen"
+
+msgctxt "#30023"
+msgid "Add to Arte favorites"
+msgstr "Zu Arte-Favoriten hinzufügen"
+
+msgctxt "#30024"
+msgid "Remove from Arte favorites"
+msgstr "Aus Arte-Favoriten entfernen"
+
+msgctxt "#30025"
+msgid "Successfully added to favorites"
+msgstr "Erfolgreich zu Favoriten hinzugefügt"
+
+msgctxt "#30026"
+msgid "Failed to add to favorites"
+msgstr "Fehler beim Hinzufügen zu den Favoriten"
+
+msgctxt "#30027"
+msgid "Successfully remove from favorites"
+msgstr "Erfolgreich aus Favoriten entfernen"
+
+msgctxt "#30028"
+msgid "Failed to remove from favorites"
+msgstr "Entfernen aus Favoriten fehlgeschlagen"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -81,3 +81,27 @@ msgstr ""
 msgctxt "#30022"
 msgid "Update your profile in settings to fetch this content"
 msgstr ""
+
+msgctxt "#30023"
+msgid "Add to Arte favorites"
+msgstr ""
+
+msgctxt "#30024"
+msgid "Remove from Arte favorites"
+msgstr ""
+
+msgctxt "#30025"
+msgid "Successfully added to favorites"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Failed to add to favorites"
+msgstr ""
+
+msgctxt "#30027"
+msgid "Successfully remove from favorites"
+msgstr ""
+
+msgctxt "#30028"
+msgid "Failed to remove from favorites"
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -81,3 +81,27 @@ msgstr "E-mail ou mot de passe manquant"
 msgctxt "#30022"
 msgid "Update your profile in settings to fetch this content"
 msgstr "Mettez à jour votre profil dans la configuration pour télécharger ce contenu"
+
+msgctxt "#30023"
+msgid "Add to Arte favorites"
+msgstr "Ajouter aux favoris Arte"
+
+msgctxt "#30024"
+msgid "Remove from Arte favorites"
+msgstr "Retirer des favoris Arte"
+
+msgctxt "#30025"
+msgid "Successfully added to favorites"
+msgstr "Ajouté aux favoris avec succès"
+
+msgctxt "#30026"
+msgid "Failed to add to favorites"
+msgstr "Erreur lors de l'ajout aux favoris"
+
+msgctxt "#30027"
+msgid "Successfully remove from favorites"
+msgstr "Retiré des favoris avec succès"
+
+msgctxt "#30028"
+msgid "Failed to remove from favorites"
+msgstr "Erreur lors du retrait des favoris"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -81,3 +81,27 @@ msgstr "E-mail o password mancanti"
 msgctxt "#30022"
 msgid "Update your profile in settings to fetch this content"
 msgstr "Aggiorna il tuo profilo nelle impostazioni per recuperare questo contenuto"
+
+msgctxt "#30023"
+msgid "Add to Arte favorites"
+msgstr "Aggiungi ai preferiti di Arte"
+
+msgctxt "#30024"
+msgid "Remove from Arte favorites"
+msgstr "Rimuovi dai preferiti di Arte"
+
+msgctxt "#30025"
+msgid "Successfully added to favorites"
+msgstr "Aggiunto con successo ai preferiti"
+
+msgctxt "#30026"
+msgid "Failed to add to favorites"
+msgstr "Impossibile aggiungere ai preferiti"
+
+msgctxt "#30027"
+msgid "Successfully remove from favorites"
+msgstr "Rimozione riuscita dai preferiti"
+
+msgctxt "#30028"
+msgid "Failed to remove from favorites"
+msgstr "Impossibile rimuovere dai preferiti"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -81,3 +81,27 @@ msgstr "Brak e-mail lub hasła"
 msgctxt "#30022"
 msgid "Update your profile in settings to fetch this content"
 msgstr "Zaktualizuj swój profil w ustawieniach, aby pobrać tę zawartość"
+
+msgctxt "#30023"
+msgid "Add to Arte favorites"
+msgstr "Dodaj do ulubionych Arte"
+
+msgctxt "#30024"
+msgid "Remove from Arte favorites"
+msgstr "Usuń z ulubionych Arte"
+
+msgctxt "#30025"
+msgid "Successfully added to favorites"
+msgstr "Pomyślnie dodano do ulubionych"
+
+msgctxt "#30026"
+msgid "Failed to add to favorites"
+msgstr "Nie udało się dodać do ulubionych"
+
+msgctxt "#30027"
+msgid "Successfully remove from favorites"
+msgstr "Pomyślnie usunięto z ulubionych"
+
+msgctxt "#30028"
+msgid "Failed to remove from favorites"
+msgstr "Nie udało się usunąć z ulubionych"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -75,6 +75,14 @@ def favorites():
     plugin.set_content('tvshows')
     return plugin.finish(view.build_favorites(plugin, settings))
 
+@plugin.route('/add_favorite/<program_id>', name='add_favorite')
+def add_favorite(program_id):
+    view.add_favorite(plugin, settings.username, settings.password, program_id)
+
+@plugin.route('/remove_favorite/<program_id>', name='remove_favorite')
+def remove_favorite(program_id):
+    view.remove_favorite(plugin, settings.username, settings.password, program_id)
+
 
 @plugin.route('/last_viewed', name='last_viewed')
 def favorites():

--- a/resources/lib/mapper.py
+++ b/resources/lib/mapper.py
@@ -1,5 +1,6 @@
 from addon import plugin
 from xbmcswift2 import xbmc
+from xbmcswift2 import actions
 
 import hof
 import utils
@@ -151,7 +152,13 @@ def map_video(item, show_video_streams):
         },
         'properties': {
             'fanart_image': item.get('imageUrl'),
-        }
+        },
+        'context_menu': [
+            (plugin.addon.getLocalizedString(30023),
+                actions.background(plugin.url_for('add_favorite', program_id=programId))),
+            (plugin.addon.getLocalizedString(30024),
+                actions.background(plugin.url_for('remove_favorite', program_id=programId))),
+        ],
     }
 
 # Create a video menu item from a json returned by Arte TV API
@@ -258,7 +265,13 @@ def map_artetv_video(item):
         },
         'properties': {
             'fanart_image': fanartUrl,
-        }
+        },
+        'context_menu': [
+            (plugin.addon.getLocalizedString(30023),
+                actions.background(plugin.url_for('add_favorite', program_id=programId))),
+            (plugin.addon.getLocalizedString(30024),
+                actions.background(plugin.url_for('remove_favorite', program_id=programId))),
+        ],
     }
 
 

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -53,9 +53,21 @@ def build_magazines(settings):
 
 def build_favorites(plugin, settings):
     return [mapper.map_artetv_video(item) for item in
-            api.favorites(plugin, settings.language, settings.username, settings.password) or
+            api.get_favorites(plugin, settings.language, settings.username, settings.password) or
             # display an empty list in case of error. error should be display in a notification
             []]
+
+def add_favorite(plugin, usr, pwd, program_id):
+    if (200 == api.add_favorite(plugin, usr, pwd, program_id)):
+        plugin.notify(msg=plugin.addon.getLocalizedString(30025), image='info')
+    else:
+        plugin.notify(msg=plugin.addon.getLocalizedString(30026), image='error')
+
+def remove_favorite(plugin, usr, pwd, program_id):
+    if (200 == api.remove_favorite(plugin, usr, pwd, program_id)):
+        plugin.notify(msg=plugin.addon.getLocalizedString(30027), image='info')
+    else:
+        plugin.notify(msg=plugin.addon.getLocalizedString(30028), image='error')
 
 
 def build_last_viewed(plugin, settings):


### PR DESCRIPTION
Manage favorites in Arte Profile from Kodi. Add option to add or remove favorite. Notify the user if favorite operation was successful (info) or not (error).
Note : Arte TV returns an HTTP status 200, even if video is not in favorites. Likewise it returns a 200, if we add a favorite that already exists.