### PR TITLE
Add GitHub workflow Kodi addon submitter + Bump version 1.1.9

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# exclude what is below from distribution zip
+.gitignore export-ignore
+.gitattributes export-ignore
+.github export-ignore
+.vscode export-ignore

--- a/.github/workflows/kodi-addon-submitter.yml
+++ b/.github/workflows/kodi-addon-submitter.yml
@@ -1,0 +1,50 @@
+# Documentation in https://github.com/xbmc/action-kodi-addon-submitter
+name: Kodi Addon-Submitter
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  kodi-addon-submitter:
+    runs-on: ubuntu-latest
+    name: Kodi addon submitter
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Generate distribution zip and submit to official kodi repository
+      id: kodi-addon-submitter
+      uses: xbmc/action-kodi-addon-submitter@v1.3
+      with:
+        kodi-repository: repo-plugins
+        kodi-version: matrix
+        addon-id: plugin.video.arteplussept
+        kodi-matrix: false
+        sub-directory: false
+      env:
+        GH_USERNAME: ${{ github.actor }}
+        # warning KODI_SUBMITTER_TOKEN is valid for 30d
+        # https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+        GH_TOKEN: ${{ secrets.KODI_SUBMITTER_TOKEN }}
+        EMAIL: ${{ secrets.EMAIL }}
+    - name: Create Github Release
+      id: create_release
+      uses: actions/create-release@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+    - name: Upload Addon zip to github release
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.kodi-addon-submitter.outputs.addon-zip }}
+        asset_name: ${{ steps.kodi-addon-submitter.outputs.addon-zip }}
+        asset_content_type: application/zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Changelog also available in file ./addon.xml xpath /addon/extension/news following Kodi guidelines https://kodi.wiki/view/Add-on_structure#changelog.txt
 
+v1.1.9 (2023-4-18)
+- Improve security and performance by caching token to limit authentication requests
+- Fallback on clip, when stream is not available anymore. Same feature as on Arte mobile. For favorite content.
+- Clean-up and lint code
+- Add CI with Pylint and Kodi addon submitter
+
 v1.1.8 (2023-2-17)
 - Improve synchronization of playback progress with Arte TV
     - Synchronize progress every minute

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.8" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.9" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -57,6 +57,10 @@ https://github.com/known-as-bmf/plugin.video.arteplussept
         <source>https://github.com/known-as-bmf/plugin.video.arteplussept</source>
         <news>
         Highlights since 1.1.2
+        - Improve security and performance by caching token to limit authentication requests
+        - Fallback on clip, when stream is not available anymore.
+        - Clean-up and lint code
+        - Add CI with Pylint and Kodi addon submitter
         - Integrate Arte account favorites, last viewed items and playback progress (thanks to Arte account to be configured in settings).
         - Move from HBB TV to Arte TV API.
         - Fixed playback progress / resume point retrieved from Arte TV
@@ -64,8 +68,6 @@ https://github.com/known-as-bmf/plugin.video.arteplussept
         - Manage favorites in Arte profile from context menu
         - Added Search in root menu
         - Added Live stream in root menu
-        - Added Polish translation
-        - Added My list and My history content from Arte TV profile
         - Added purge of my history
         </news>
         <assets>

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -10,7 +10,7 @@ from . import hof
 # Arte hbbtv - deprecated API since 2022 prefer Arte TV API
 _HBBTV_URL = 'http://www.arte.tv/hbbtvv2/services/web/index.php'
 _HBBTV_HEADERS = {
-    'user-agent': 'plugin.video.arteplussept/1.1.8'
+    'user-agent': 'plugin.video.arteplussept/1.1.9'
 }
 _HBBTV_ENDPOINTS = {
     'category': '/EMAC/teasers/category/v2/{category_code}/{lang}',
@@ -60,7 +60,7 @@ ARTETV_ENDPOINTS = {
     'login': '/login',
 }
 ARTETV_HEADERS = {
-    'user-agent': 'plugin.video.arteplussept/1.1.8',
+    'user-agent': 'plugin.video.arteplussept/1.1.9',
     # required to use token endpoint
     'authorization': 'I6k2z58YGO08P1X0E8A7VBOjDxr8Lecg',
     # required for Arte TV API. values like web, app, tv, orange, free


### PR DESCRIPTION
- Add GitHub workflow Kodi addon submitter to automaticaly submit addon to kodi official and create a release, when pushing a tag starting with "v" for version.
- Bump version 1.1.9
