### PR TITLE
Manage collections TV_SERIES and MAGAZINE as video playlist

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -56,6 +56,25 @@ def cached_category(category_code):
     return view.get_cached_category(category_code, plugin.get_storage('cached_categories', TTL=60))
 
 
+@plugin.route('/playlist/<kind>/<collection_id>', name='playlist')
+def playlist(kind, collection_id):
+    """
+    Load a playlist and start playing its first item.
+    """
+    pair = view.build_collection_playlist(kind, collection_id, settings)
+
+    # Empty playlist, otherwise requested video is present twice in the playlist
+    xbmc.PlayList(xbmc.PLAYLIST_VIDEO).clear()
+    # Start playing with the first playlist item
+    synched_player = Player(plugin, settings, pair['start_program_id'])
+    # try to seek parent collection, when out of the context of playlist creation
+    # Start playing with the first playlist item
+    result = plugin.set_resolved_url(plugin.add_to_playlist(pair['listitems'])[0])
+    synch_during_playback(synched_player)
+    del synched_player
+    return result
+
+
 @plugin.route('/favorites', name='favorites')
 def favorites():
     """Display the menu for user favorites"""
@@ -130,14 +149,32 @@ def play_live(stream_url):
 
 @plugin.route('/play/<kind>/<program_id>', name='play')
 @plugin.route('/play/<kind>/<program_id>/<audio_slot>', name='play_specific')
-def play(kind, program_id, audio_slot='1'):
+@plugin.route('/play/<kind>/<program_id>/<audio_slot>/<from_playlist>', name='play_collection')
+def play(kind, program_id, audio_slot='1', from_playlist='0'):
     """Play content identified with program_id.
     :param str kind: an enum in TODO (e.g. TRAILER, COLLECTION, LINK, CLIP, ...)
     :param str audio_slot: a numeric to identify the audio stream to use e.g. 1 2
     """
     synched_player = Player(plugin, settings, program_id)
-    item = view.build_stream_url(plugin, kind, program_id, int(audio_slot), settings)
-    result = plugin.set_resolved_url(item)
+    # try to seek parent collection, when out of the context of playlist creation
+    sibling_items = None
+    if from_playlist == '0':
+        sibling_items = view.build_sibling_playlist(program_id, settings)
+    if sibling_items is not None and len(sibling_items) > 1:
+        # Empty playlist, otherwise requested video is present twice in the playlist
+        xbmc.PlayList(xbmc.PLAYLIST_VIDEO).clear()
+        # Start playing with the first playlist item
+        result = plugin.set_resolved_url(plugin.add_to_playlist(sibling_items)[0])
+    else:
+        item = view.build_stream_url(plugin, kind, program_id, int(audio_slot), settings)
+        result = plugin.set_resolved_url(item)
+    synch_during_playback(synched_player)
+    del synched_player
+    return result
+
+
+def synch_during_playback(synched_player):
+    """Manage timeframe to send synchronization events to Arte TV API"""
     # wait 1s first to give a chance for playback to start
     # otherwise synched_player won't be able to listen
     xbmc.sleep(500)
@@ -151,8 +188,6 @@ def play(kind, program_id, audio_slot='1'):
         i += 1
         xbmc.sleep(1000)
     synched_player.synch_progress()
-    del synched_player
-    return result
 
 
 @plugin.route('/search', name='search')

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -178,6 +178,28 @@ def collection(kind, collection_id, lang):
         lambda sub_collections: sub_collections.get('videos', []),
         sub_collections)
 
+# pylint: disable=too-many-arguments
+def collection_with_last_viewed(plugin, lang, usr, pwd, kind, collection_id):
+    """
+    Get the info of collection collection_id and enhanced them with last_viewed details
+    e.g. progress
+    """
+    collection_items = collection(kind, collection_id, lang)
+    last_viewed_items = get_last_viewed(plugin, lang, usr, pwd)
+    # nothing to do
+    if len(collection_items) < 1 or last_viewed_items is None or len(last_viewed_items) < 1:
+        return collection_items
+    # merge the 2 collection based on program id.
+    last_viewed_map = {}
+    for item in last_viewed_items:
+        last_viewed_map[item.get('programId')] = item
+    for idx, basic_item in enumerate(collection_items):
+        if basic_item is not None and basic_item.get('programId') is not None:
+            enhanced_item = last_viewed_map.get(basic_item.get('programId'))
+            if enhanced_item is not None:
+                collection_items[idx] = enhanced_item
+    return collection_items
+
 
 def video(program_id, lang):
     """Get the info of content program_id from HBB TV API."""

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -81,8 +81,10 @@ def get_favorites(plugin, lang, usr, pwd):
     return _load_json_personal_content(plugin, 'artetv_getfavorites', url, usr, pwd)
 
 def add_favorite(plugin, usr, pwd, program_id):
-    """Add content program_id to user favorites.
-    :return: HTTP status code."""
+    """
+    Add content program_id to user favorites.
+    :return: HTTP status code.
+    """
     url = _ARTETV_URL + ARTETV_ENDPOINTS['add_favorite']
     headers = _add_auth_token(plugin, usr, pwd, ARTETV_HEADERS)
     data = {'programId': program_id}
@@ -91,8 +93,10 @@ def add_favorite(plugin, usr, pwd, program_id):
     return reply.status_code
 
 def remove_favorite(plugin, usr, pwd, program_id):
-    """Remove content program_id from user favorites.
-    :return: HTTP status code."""
+    """
+    Remove content program_id from user favorites.
+    :return: HTTP status code.
+    """
     url = _ARTETV_URL + ARTETV_ENDPOINTS['remove_favorite'].format(program_id=program_id)
     headers = _add_auth_token(plugin, usr, pwd, ARTETV_HEADERS)
     reply = requests.delete(url, headers=headers, timeout=10)
@@ -113,8 +117,10 @@ def get_last_viewed(plugin, lang, usr, pwd):
     return _load_json_personal_content(plugin, 'artetv_lastviewed', url, usr, pwd)
 
 def sync_last_viewed(plugin, usr, pwd, program_id, time):
-    """Synchronize in arte profile the progress time of content being played.
-    :return: HTTP status code."""
+    """
+    Synchronize in arte profile the progress time of content being played.
+    :return: HTTP status code.
+    """
     url = _ARTETV_URL + ARTETV_ENDPOINTS['sync_last_viewed']
     headers = _add_auth_token(plugin, usr, pwd, ARTETV_HEADERS)
     data = {'programId': program_id, 'timecode': time}
@@ -140,6 +146,22 @@ def program_video(lang, program_id):
     url = ARTETV_RPROXY_URL + ARTETV_ENDPOINTS['program'].format(lang=lang, program_id=program_id)
     return _load_json_full_url('artetv_program', url, None).get('value', {})
 
+def get_parent_collection(lang, program_id):
+    """
+    Get parent collection of program program_id.
+    Return an empty list, if nothing found.
+    """
+    artetv_program_stream = program_video(lang, program_id)
+    if artetv_program_stream:
+        for zone in artetv_program_stream.get('zones', []):
+            if zone.get('content'):
+                for data in zone.get('content').get('data'):
+                    return data.get('parentCollections', [])
+    return []
+
+def is_of_kind(arte_item, kind):
+    """Return true if arte_item is not None and of the kind provided as parameter"""
+    return (arte_item and arte_item.get('kind') == kind) or False
 
 def category(category_code, lang):
     """Get the info of category with category_code."""

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -25,7 +25,9 @@ class Player(xbmc.Player):
             # RuntimeError: Kodi is not playing any media file
             # when calling player.getTime() in onPlayBackStopped()
             self.last_time = self.getTime()
-            return self.isPlaying() and self.isPlayingVideo() and self.last_time >= 0
+            # when playing video playlist, isPlayingVideo() is False, isPlaying() is True
+            return (self.isPlaying() or self.isPlayingVideo() or self.isPlayingAudio()) \
+                and self.last_time >= 0
         # pylint: disable=broad-exception-caught
         # https://codedocs.xyz/MartijnKaijser/xbmc/group__python___player.html
         except Exception:

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -76,3 +76,20 @@ def is_playlist(program_id):
     if isinstance(program_id, str):
         is_playlist_var = program_id.startswith('RC-') or program_id.startswith('PL-')
     return is_playlist_var
+
+
+def get_progress(item):
+    """
+    Return item progress or 0 as float.
+    Never None, even if lastviewed or item is None.
+    """
+    # pylint raises that it is not snake_case. it's in uppercase, because it's a constant
+    # pylint: disable=invalid-name
+    DEFAULT_PROGRESS = 0.0
+    if not item:
+        return DEFAULT_PROGRESS
+    if not item.get('lastviewed'):
+        return DEFAULT_PROGRESS
+    if not item.get('lastviewed').get('progress'):
+        return DEFAULT_PROGRESS
+    return float(item.get('lastviewed') and item.get('lastviewed').get('progress'))

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -142,10 +142,11 @@ def build_video_streams(program_id, settings):
         item, api.streams(kind, program_id, settings.language), settings.quality)
 
 
-def build_sibling_playlist(program_id, settings):
+def build_sibling_playlist(plugin, settings, program_id):
     """
-    Return as a playlist videos belonging to the same parent
+    Return a pair with videos belonging to the same parent as program id
     e.g. other episodes of a same serie, videos around the same topic
+    and the start program id of this collection i.e. program_id
     """
     parent_program = None
     # get parent of prefered kind first. for the moment TV_SERIES only
@@ -158,21 +159,19 @@ def build_sibling_playlist(program_id, settings):
             break
     # if a parent was found, then return the list of kodi playable dict.
     if parent_program:
-        sibling_arte_items = api.collection(
-            parent_program.get('kind'), parent_program.get('programId'), settings.language)
+        sibling_arte_items = api.collection_with_last_viewed(
+            plugin, settings.language, settings.username, settings.password,
+            parent_program.get('kind'), parent_program.get('programId'))
         return mapper.map_collection_as_playlist(sibling_arte_items, program_id)
     return None
 
-def build_collection_playlist(kind, collection_id, settings):
+def build_collection_playlist(plugin, settings, kind, collection_id):
     """
-    Return a pair with list items for collection with id collection_id
-    and program id of the first element
+    Return a pair with collection with collection_id
+    and program id of the first element in the collection
     """
-    playlist_api_items = api.collection(kind, collection_id, settings.language)
-    start_program_id = playlist_api_items[0].get('programId')
-    return {
-        'listitems' : mapper.map_collection_as_playlist(playlist_api_items, start_program_id),
-        'start_program_id': start_program_id}
+    return mapper.map_collection_as_playlist(api.collection_with_last_viewed(
+        plugin, settings.language, settings.username, settings.password, kind, collection_id))
 
 def build_stream_url(plugin, kind, program_id, audio_slot, settings):
     """


### PR DESCRIPTION
- Load serie as a playlist and play first item, when opening a serie menu
- Load playlist of the serie, when requesting to play one of its episodes
- Keep synchronization of progress with Arte account
- Start playlist from the first non fully watched elements

Only TV_SERIES and MAGAZINE have been adapted, but other set of videos (e.g TOPIC) could be managed the same way.