### PR TITLE
Add a context menu item to mark as video as watched in Arte

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -76,6 +76,13 @@ def remove_favorite(program_id, label):
     useful when several operations are requested in parallel."""
     view.remove_favorite(plugin, settings.username, settings.password, program_id, label)
 
+@plugin.route('/mark_as_watched/<program_id>/<label>', name='mark_as_watched')
+def mark_as_watched(program_id, label):
+    """Mark program as watched in Arte
+    Notify about completion status with label,
+    useful when several operations are requested in parallel."""
+    view.mark_as_watched(plugin, settings.username, settings.password, program_id, label)
+
 
 @plugin.route('/last_viewed', name='last_viewed')
 def last_viewed():

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -98,3 +98,15 @@ msgstr "Videoverlauf erfolgreich gelöscht"
 msgctxt "#30032"
 msgid "Failed to purge my history"
 msgstr "Mein Videoerlauf konnte nicht gelöscht werden"
+
+msgctxt "#30033"
+msgid "Mark as watched in Arte"
+msgstr "Als geschaut in Arte markieren"
+
+msgctxt "#30034"
+msgid "\"{label}\" successfully marked as watched"
+msgstr "\"{label}\" erfolgreich als geschaut markiert"
+
+msgctxt "#30035"
+msgid "Failed to mark as watched \"{label}\""
+msgstr "\"{label}\" konnte nicht als geschaut markiert werden"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -98,3 +98,15 @@ msgstr ""
 msgctxt "#30032"
 msgid "Failed to purge my history"
 msgstr ""
+
+msgctxt "#30033"
+msgid "Mark as watched in Arte"
+msgstr ""
+
+msgctxt "#30034"
+msgid "\"{label}\" successfully marked as watched"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Failed to mark as watched \"{label}\""
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -98,3 +98,15 @@ msgstr "Historique purgé avec succès"
 msgctxt "#30032"
 msgid "Failed to purge my history"
 msgstr "Echec de la purge de mon historique"
+
+msgctxt "#30033"
+msgid "Mark as watched in Arte"
+msgstr "Marquer comme lu dans Arte"
+
+msgctxt "#30034"
+msgid "\"{label}\" successfully marked as watched"
+msgstr "\"{label}\" marqué comme lu avec succès"
+
+msgctxt "#30035"
+msgid "Failed to mark as watched \"{label}\""
+msgstr "Echec pour marquer comme lu \"{label}\""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -98,3 +98,15 @@ msgstr "Cronologia eliminata con successo"
 msgctxt "#30032"
 msgid "Failed to purge my history"
 msgstr "Impossibile eliminare la cronologia"
+
+msgctxt "#30033"
+msgid "Mark as watched in Arte"
+msgstr "Segna come guardato in Arte"
+
+msgctxt "#30034"
+msgid "\"{label}\" successfully marked as watched"
+msgstr "\"{label}\" contrassegnato con successo come guardato"
+
+msgctxt "#30035"
+msgid "Failed to mark as watched \"{label}\""
+msgstr "Impossibile contrassegnare come guardato \"{label}\""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -98,3 +98,15 @@ msgstr "Pomyślnie wyczyszczono historię"
 msgctxt "#30032"
 msgid "Failed to purge my history"
 msgstr "Nie udało się wyczyścić mojej historii"
+
+msgctxt "#30033"
+msgid "Mark as watched in Arte"
+msgstr "Oznacz jako obejrzane w Arte"
+
+msgctxt "#30034"
+msgid "\"{label}\" successfully marked as watched"
+msgstr "Pomyślnie oznaczone \"{label}\" jako obejrzane"
+
+msgctxt "#30035"
+msgid "Failed to mark as watched \"{label}\""
+msgstr "Nie udało się oznaczyć jako oglądane \"{label}\""

--- a/resources/lib/mapper.py
+++ b/resources/lib/mapper.py
@@ -106,6 +106,9 @@ def map_video(item, show_video_streams):
             (plugin.addon.getLocalizedString(30024),
                 actions.background(plugin.url_for(
                     'remove_favorite', program_id=program_id, label=label))),
+            (plugin.addon.getLocalizedString(30033),
+                actions.background(plugin.url_for(
+                    'mark_as_watched', program_id=program_id, label=label))),
         ],
     }
 
@@ -181,6 +184,9 @@ def map_artetv_video(item):
             (plugin.addon.getLocalizedString(30024),
                 actions.background(plugin.url_for(
                     'remove_favorite', program_id=program_id, label=label))),
+            (plugin.addon.getLocalizedString(30033),
+                actions.background(plugin.url_for(
+                    'mark_as_watched', program_id=program_id, label=label))),
         ],
     }
 

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -4,6 +4,7 @@ from xbmcswift2 import xbmc
 
 from . import api
 from . import mapper
+from . import settings as stg
 
 
 def build_home_page(cached_categories, settings):
@@ -71,6 +72,28 @@ def remove_favorite(plugin, usr, pwd, program_id, label):
         plugin.notify(msg=msg, image='info')
     else:
         msg = plugin.addon.getLocalizedString(30028).format(label=label)
+        plugin.notify(msg=msg, image='error')
+
+
+def mark_as_watched(plugin, usr, pwd, program_id, label):
+    """
+    Get program duration and synch progress with total duration
+    in order to mark a program as watched
+    """
+    status = -1
+    try:
+        program_info = api.player_video(stg.languages[0], program_id)
+        total_time = program_info.get('attributes').get('metadata').get('duration').get('seconds')
+        status = api.sync_last_viewed(plugin, usr, pwd, program_id, total_time)
+    # pylint: disable=broad-exception-caught
+    except Exception as excp:
+        xbmc.log(f" exception caught :{str(excp)}")
+
+    if 200 == status:
+        msg = plugin.addon.getLocalizedString(30034).format(label=label)
+        plugin.notify(msg=msg, image='info')
+    else:
+        msg = plugin.addon.getLocalizedString(30035).format(label=label)
         plugin.notify(msg=msg, image='error')
 
 


### PR DESCRIPTION
Playable videos can be marked as watched in Arte thanks to a new context menu item.