### PR TITLE
Bump to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog also available in file ./addon.xml xpath /addon/extension/news following Kodi guidelines https://kodi.wiki/view/Add-on_structure#changelog.txt
 
+v1.2.0 (2023-7-26)
+- Manage collections TV_SERIES and MAGAZINE as video playlist
+- Add a context menu item to purge favorites
+- Add a context menu item to mark as video as watched in Arte
+
 v1.1.10 (2023-5-28)
 - Bugfix to display favorites and last vieweds following id change in Arte
 

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.10" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.2.0" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -56,19 +56,10 @@ https://github.com/known-as-bmf/plugin.video.arteplussept
         <website>https://www.arte.tv/fr/</website>
         <source>https://github.com/known-as-bmf/plugin.video.arteplussept</source>
         <news>
-        Highlights since 1.1.2
-        - Improve security and performance by caching token to limit authentication requests
-        - Fallback on clip, when stream is not available anymore.
-        - Clean-up and lint code
-        - Add CI with Pylint and Kodi addon submitter
-        - Integrate Arte account favorites, last viewed items and playback progress (thanks to Arte account to be configured in settings).
-        - Move from HBB TV to Arte TV API.
-        - Fixed playback progress / resume point retrieved from Arte TV
-        - Added synchronisation of playback progress with Arte TV when video playback paused, stopped or crashed
-        - Manage favorites in Arte profile from context menu
-        - Added Search in root menu
-        - Added Live stream in root menu
-        - Added purge of my history
+        Highlights since 1.1.10
+        - Manage collections TV_SERIES and MAGAZINE as video playlist
+        - Add a context menu item to purge favorites
+        - Add a context menu item to mark as video as watched in Arte
         </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -4,14 +4,16 @@ from collections import OrderedDict
 import requests
 # pylint: disable=import-error
 from xbmcswift2 import xbmc
+from xbmcswift2.plugin import Plugin
 from . import hof
 from . import logger
 
-
+_PLUGIN_NAME = Plugin().name
+_PLUGIN_VERSION = Plugin().addon.getAddonInfo('version')
 # Arte hbbtv - deprecated API since 2022 prefer Arte TV API
 _HBBTV_URL = 'http://www.arte.tv/hbbtvv2/services/web/index.php'
 _HBBTV_HEADERS = {
-    'user-agent': 'plugin.video.arteplussept/1.1.10'
+    'user-agent': f"{_PLUGIN_NAME}/{_PLUGIN_VERSION}"
 }
 _HBBTV_ENDPOINTS = {
     'category': '/EMAC/teasers/category/v2/{category_code}/{lang}',
@@ -66,7 +68,7 @@ ARTETV_ENDPOINTS = {
     'login': '/login',
 }
 ARTETV_HEADERS = {
-    'user-agent': 'plugin.video.arteplussept/1.1.10',
+    'user-agent': f"{_PLUGIN_NAME}/{_PLUGIN_VERSION}",
     # required to use token endpoint
     'authorization': 'I6k2z58YGO08P1X0E8A7VBOjDxr8Lecg',
     # required for Arte TV API. values like web, app, tv, orange, free


### PR DESCRIPTION
- Manage collections TV_SERIES and MAGAZINE as video playlist
- Add a context menu item to purge favorites
- Add a context menu item to mark as video as watched in Arte
