### PR TITLE
Bugfix/playing sequence already watched videos

### DIFF
--- a/resources/lib/mapper.py
+++ b/resources/lib/mapper.py
@@ -281,7 +281,10 @@ def map_artetv_item_new(item, path, is_playable):
             # ResumeTime and TotalTime deprecated. Use InfoTagVideo.setResumePoint() instead.
             'ResumeTime': str(time_offset),
             'TotalTime': str(duration),
-            'StartPercent': str(progress * 100)
+            #'StartPercent': str(progress * 100),
+            'StartPercent': '0' if duration is None else str(
+                float(time_offset if isinstance(time_offset, int) else 0) * 100.0
+                / float(duration)),
         },
         'context_menu': [
             (plugin.addon.getLocalizedString(30023),


### PR DESCRIPTION
When videos are already watched, their progress / start percent property is almost 100. So, playback start at the end of the video.
When several such videos are in sequence and user request Kodi to play one of the first videos, then playback start and restart over again in sequence, which makes Kodi fails.

Use the start offset of Arte API reply which is back to 0 even when a video is already watched. Stop using progress in Arte API reply to populate StartPercent property.