### PR TITLE
#39 Rename values for quality configuration

### DIFF
--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -3,7 +3,9 @@
 import dataclasses
 
 languages = ['fr', 'de', 'en', 'es', 'pl', 'it']
-qualities = ['SQ', 'EQ', 'HQ']
+# though misleqding the below mapping is correct e.g. SQ is High Quality 720p
+# dict keys must be in same order as in settings.xml
+quality_map = {'Low': 'HQ', 'Medium': 'EQ', 'High': 'SQ'}
 loglevel = ['DEFAULT', 'API']
 
 
@@ -16,9 +18,9 @@ class Settings:
         self.language = plugin.get_setting(
             'lang', choices=languages) or languages[0]
         # Quality of the videos
-        # defaults to SQ
-        self.quality = plugin.get_setting(
-            'quality', choices=qualities) or qualities[0]
+        # defaults to High, SQ, 720p
+        self.quality = quality_map[plugin.get_setting(
+            'quality', choices=list(quality_map.keys()))] or quality_map['High']
         # Should the plugin display all available streams for videos?
         # defaults to False
         self.show_video_streams = plugin.get_setting(

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -12,8 +12,8 @@
 			id="quality"
 			type="enum"
 			label="30052"
-			values="SQ (High)|EQ (Medium)|HQ (Low)"
-			default="0"/>
+			values="Low|Medium|High"
+			default="2"/>
 		<setting
 			id="show_video_streams"
 			type="bool"


### PR DESCRIPTION
Rename HQ to Low, EQ to Medium and SQ to High.

Minor improvement related to issue #39 