### PR TITLE
Refresh ARTE TV multi lang support with recent minor fixes and improvements

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -11,7 +11,7 @@ from resources.lib import logger
 _PLUGIN_NAME = Plugin().name
 _PLUGIN_VERSION = Plugin().addon.getAddonInfo('version')
 # Arte hbbtv - deprecated API since 2022 prefer Arte TV API
-_HBBTV_URL = 'http://www.arte.tv/hbbtvv2/services/web/index.php'
+_HBBTV_URL = 'https://www.arte.tv/hbbtvv2/services/web/index.php'
 _HBBTV_HEADERS = {
     'user-agent': f"{_PLUGIN_NAME}/{_PLUGIN_VERSION}"
 }

--- a/resources/lib/mapper/artecollection.py
+++ b/resources/lib/mapper/artecollection.py
@@ -30,7 +30,11 @@ class ArteCollection:
         # Abstract class should NOT be instantiated
         # pylint: disable=assignment-from-none
         meta = self._get_page_meta(json_dict)
-        items = [ArteTvVideoItem(self.plugin, item).map_artetv_item() for item in pages]
+        items = []
+        for page_item in pages:
+            menu_item = ArteTvVideoItem(self.plugin, page_item).map_artetv_item()
+            if menu_item is not None:
+                items.append(menu_item)
         if meta and meta.get('pages', False):
             total_pages = meta.get('pages')
             current_page = meta.get('page')

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -3,7 +3,9 @@
 import dataclasses
 
 languages = ['fr', 'de', 'en', 'es', 'pl', 'it']
-qualities = ['SQ', 'EQ', 'HQ']
+# though misleqding the below mapping is correct e.g. SQ is High Quality 720p
+# dict keys must be in same order as in settings.xml
+quality_map = {'Low': 'HQ', 'Medium': 'EQ', 'High': 'SQ'}
 loglevel = ['DEFAULT', 'API']
 
 
@@ -16,9 +18,9 @@ class Settings:
         self.language = plugin.get_setting(
             'lang', choices=languages) or languages[0]
         # Quality of the videos
-        # defaults to SQ
-        self.quality = plugin.get_setting(
-            'quality', choices=qualities) or qualities[0]
+        # defaults to High, SQ, 720p
+        self.quality = quality_map[plugin.get_setting(
+            'quality', choices=list(quality_map.keys()))] or quality_map['High']
         # Should the plugin display all available streams for videos?
         # defaults to False
         self.show_video_streams = plugin.get_setting(

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -112,7 +112,7 @@ def build_sibling_playlist(plugin, settings, program_id):
         sibling_arte_items = api.collection_with_last_viewed(
             settings.language, user.get_cached_token(plugin, settings.username, True),
             parent_program.get('kind'), parent_program.get('programId'))
-        return mapper.map_collection_as_playlist(sibling_arte_items, program_id)
+        return mapper.map_collection_as_playlist(plugin, sibling_arte_items, program_id)
     return None
 
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -12,8 +12,8 @@
 			id="quality"
 			type="enum"
 			label="30052"
-			values="SQ (High)|EQ (Medium)|HQ (Low)"
-			default="0"/>
+			values="Low|Medium|High"
+			default="2"/>
 		<setting
 			id="show_video_streams"
 			type="bool"


### PR DESCRIPTION
- Fix external item mapped to none in cached categories
    - ARTE TV item of kind External link were mapped to None in cached_categories.
    - Display of cached_categories was failing due to None element.
- HTTPS instead of HTTP for HHB TV API calls
- Rename quality configuration values to avoid confusion involved by HBB TV API values : Low HQ, Medium EQ, High SQ