### PR TITLE
Fix external item mapped to none in cached categories

### DIFF
--- a/resources/lib/mapper/artecollection.py
+++ b/resources/lib/mapper/artecollection.py
@@ -30,7 +30,11 @@ class ArteCollection:
         # Abstract class should NOT be instantiated
         # pylint: disable=assignment-from-none
         meta = self._get_page_meta(json_dict)
-        items = [ArteTvVideoItem(self.plugin, item).map_artetv_item() for item in pages]
+        items = []
+        for page_item in pages:
+            menu_item = ArteTvVideoItem(self.plugin, page_item).map_artetv_item()
+            if menu_item is not None:
+                items.append(menu_item)
         if meta and meta.get('pages', False):
             total_pages = meta.get('pages')
             current_page = meta.get('page')


### PR DESCRIPTION
ARTE TV item of kind External link were mapped to None in cached_categories.
Display of cached_categories was failing due to None element.