### PR TITLE
Bugfix for issue 50 unable to read live stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 Changelog also available in file ./addon.xml xpath /addon/extension/news following Kodi guidelines https://kodi.wiki/view/Add-on_structure#changelog.txt
 
+v1.4.3 (2025-8-4)
+- Fix playing live stream (disabling HLS).
+
+v1.4.2 (2024-1-3)
+- Rename quality parameter.
+- Use https to get HBB TV Stream info.
+- Fix bug preventing to open series menu
+
 v1.4.1 (2023-10-10)
 - Fix playing videos with siblings.
 

--- a/addon.py
+++ b/addon.py
@@ -154,13 +154,14 @@ def streams(program_id):
     return plugin.finish(view.build_video_streams(plugin, settings, program_id))
 
 
-@plugin.route('/play_live/<stream_url>', name='play_live')
-def play_live(stream_url):
-    """Play live content."""
-    return plugin.set_resolved_url({'path': stream_url})
-
 # Cannot read video new arte tv program API. Blocked by FFMPEG issue #10149
 # @plugin.route('/play_artetv/<program_id>', name='play_artetv')
+#
+# @plugin.route('/play_live/<stream_url>', name='play_live')
+# def play_live(stream_url):
+#    """Play live content."""
+#    return plugin.set_resolved_url({'path': stream_url})
+#
 # def play_artetv(program_id):
 #     item = api.player_video(settings.language, program_id)
 #     attr = item.get('attributes')

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.4.1" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.4.3" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -56,19 +56,17 @@ https://github.com/thomas-ernest/plugin.video.arteplussept
         <website>https://www.arte.tv/fr/</website>
         <source>https://github.com/thomas-ernest/plugin.video.arteplussept</source>
         <news>
+v1.4.3 (2025-8-4)
+- Fix playing live stream (disabling HLS).
+v1.4.2 (2024-1-3)
+- Rename quality parameter.
+- Use https to get HBB TV Stream info.
+- Fix bug preventing to open series menu
 v1.4.1 (2023-10-10)
 - Fix playing videos with siblings.
 v1.4.0 (2023-8-14)
 - Add support for content over multiple pages.
 - Refactor most of the code in OO style
-v1.3.1 (2023-8-12)
-- Add context menu to view collection as menu instead of playlist
-- Set resume point to 0 when video was fully watched. Avoid crash when playing seq of watched videos in playlist.
-v1.3.0 (2023-8-6)
-- Improve security with better password management
-        - Stop storing password on filesystem though addon settings
-- Make thomas-ernest fork official in addon.xml for visibility in wiki
-- Minor fix/clean-up in translation
         </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/resources/lib/mapper/arteitem.py
+++ b/resources/lib/mapper/arteitem.py
@@ -307,7 +307,7 @@ class ArteHbbTvVideoItem(ArteVideoItem):
                 # year is not correctly used by kodi :(
                 # the aired year will be used by kodi for production year :(
                 # 'year': int(config.get('productionYear')),
-                'country': [country.get('label') for country in \
+                'country': [country.get('label') for country in
                             item.get('productionCountries', [])],
                 'director': item.get('director'),
             },

--- a/resources/lib/mapper/live.py
+++ b/resources/lib/mapper/live.py
@@ -5,7 +5,6 @@ for map_playable and match_hbbtv
 
 import html
 # the goal is to break/limit this dependency as much as possible
-from resources.lib.mapper import mapper
 from resources.lib.mapper.arteitem import ArteTvVideoItem
 
 
@@ -27,10 +26,11 @@ class ArteLiveItem(ArteTvVideoItem):
             label += f" - {html.unescape(subtitle)}"
         return label
 
-    def build_item_live(self, quality, audio_slot):
+    def build_item_live(self):
         """Return menu entry to watch live content from Arte TV API"""
-        # program_id = item.get('id')
         item = self.json_dict
+        # Remove language at the end e.g. _fr, _de
+        program_id = item.get('id')[:-3]
         attr = item.get('attributes')
         meta = attr.get('metadata')
 
@@ -48,12 +48,10 @@ class ArteLiveItem(ArteTvVideoItem):
             #    smallerImage = item.get('images')[0].get('alternateResolutions')[3]
             #    if smallerImage and smallerImage.get('url'):
             #        thumbnailUrl = smallerImage.get('url').replace('?type=TEXT', '')
-        stream_url = mapper.map_playable(
-            attr.get('streams'), quality, audio_slot, mapper.match_artetv).get('path')
 
         return {
             'label': self.format_title_and_subtitle(),
-            'path': self.plugin.url_for('play_live', stream_url=stream_url),
+            'path': self.plugin.url_for('play', kind='SHOW', program_id=program_id),
             # playing the stream from program id makes the live starts from the beginning
             # while it starts the video like the live tv, with the above
             #  'path': plugin.url_for('play', kind='SHOW', program_id=programId.replace('_fr', '')),

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -20,7 +20,7 @@ def build_home_page(plugin, settings, cached_categories):
     try:
         addon_menu.append(
             ArteLiveItem(plugin, api.player_video(settings.language, 'LIVE'))
-            .build_item_live(settings.quality, '1'))
+            .build_item_live())
     # pylint: disable=broad-exception-caught
     # Could be improve. possible exceptions are limited to auth. errors
     except Exception as error:


### PR DESCRIPTION
Load old Arte content instead of recent HLS M3U8 stream, which is not supported by underlying FFMPEG decoder as reported in issue #10149 https://trac.ffmpeg.org/ticket/10149.
We loose the live stream as on TV. Content will always be started from scratch.