### PR TITLE
Bugfix issue #54 unable to authenticate

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -362,9 +362,10 @@ def get_and_persist_token_in_arte(plugin, username, password):
     if not tokens:
         return None
 
+    # Disable failing persisting token due to new SSO v4
     # try to persist token in arte to be allowed to reuse; otherwise token is one-shot
-    if not persist_token_in_arte(plugin, tokens):
-        return None
+    # if not persist_token_in_arte(plugin, tokens):
+    #    return None
 
     # return persisted or unpersisted token anyway
     return tokens

--- a/resources/lib/mapper/arteitem.py
+++ b/resources/lib/mapper/arteitem.py
@@ -159,7 +159,6 @@ class ArteTvVideoItem(ArteVideoItem):
         Return video menu item to show content from Arte TV API.
         Manage specificities of various types : playlist, menu or video items
         """
-        item = self.json_dict
         program_id = self._get_program_id()
         kind = self._get_kind()
         if kind == 'EXTERNAL':
@@ -286,18 +285,18 @@ class ArteTvVideoItem(ArteVideoItem):
     def _get_time_offset(self):
         item = self.json_dict
         return item.get('lastviewed') and item.get('lastviewed').get('timecode') or 0
-    
+
     def _get_program_id(self):
         """
-        Return item program's identifier or 
+        Return item program's identifier or
         item's identifier and fix JSON dictionary if None in some playlist
-        """        
+        """
         item = self.json_dict
         program_id = item.get('programId')
         if program_id is None:
             program_id = item.get('id')
             item['programId'] = program_id
-            
+
         return program_id
 
 


### PR DESCRIPTION
Arte TV API has changed its authentication solution moving from SSO v3 to v4.
New v4 has not been implemented, but the call to an unavailable endpoint has been removed.