### PR TITLE
Simplify Arte+7 addon release creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,32 @@ If you are having issues with the add-on, you can open a issue and join your log
 
 ## Releasing
 
-- For minor version, create a new release branch `release/$MAJOR.$MINOR`. Don't mention bugfix version.
-- Add details of the news version in CHANGELOG.md. Do not touch changelog.txt. It is here for legacy purpose.
+### Releasing part on contributo's host
+
+Steps to be followed by a contributor to create a release.
+
+- Releases are created in master branch. Make sure HEAD in master reflects the content of the next release.
 - Set the version $MAJOR.$MINOR.$BUGFIX (without v) in addon.xml /addon/@version 
-- Optionally update highlight changes in addon.xml /addon/extension[@point="xbmc.addon.metadata"]/news. Ensure it counts less than 1500 chars.
+- Describe the changes of the news version in:
+    - CHANGELOG.md. Ignore changelog.txt remaining here for legacy purpose.
+    - addon.xml /addon/extension[@point="xbmc.addon.metadata"]/news. Ensure it counts less than 1500 chars.
 - Create a commit with version bump
     - git add addon.xml CHANGELOG.md && git commit -m "Bump version to $MAJOR.$MINOR.$BUGFIX"
-- Create and push tag "vMaj.Min.Bug" (with v) in git in order to create a GitHub release and submit [PR to official repo](https://github.com/xbmc/repo-plugins/pulls).
+- Create and push tag "vMaj.Min.Bug" (with v) to GitHub in order to create a GitHub release and submit a [PR to official XBMC repo](https://github.com/xbmc/repo-plugins/pulls) with the CI.
     - git tag -a v$MAJOR.$MINOR.$BUGFIX
+    - Fill the tag message with the description of the changes of the news version. It will be used as GitHub release notes.
     - git push origin --tags
-- Done automatically by CI : Create a release in GitHub with name $MAJOR.$MINOR.$BUGFIX (without v). Reuse CHANGELOG.md details as description. https://github.com/thomas-ernest/plugin.video.arteplussept/releases/new
-- Done automatically by CI : Submit new version to official Kodi repository
-    - One-commit change in matrix branch https://kodi.wiki/view/Submitting_Add-ons
-    - Open pull-request to official repo https://github.com/xbmc/repo-plugins/pulls
+
+### Releasing part in CI
+
+Steps run automatically by CI, with troubleshooting guide.
+
+- "Kodi Addon-Submitter" in CI is in charge of:
+    - creating a GitHub release with version $MAJOR.$MINOR.$BUGFIX in https://github.com/thomas-ernest/plugin.video.arteplussept/releases
+    - submitting a new version to official Kodi repository
+        - One-commit change in matrix branch https://kodi.wiki/view/Submitting_Add-ons
+        - Open pull-request to official repo https://github.com/xbmc/repo-plugins/pulls
+- if the action "Kodi Addon-Submitter" in CI  fails, refresh the token value in action secret.
+    - In https://github.com/settings/tokens/ generate a corsed-grained token KODI_SUBMITTER_TOKEN_CLASSIC and copy its value
+    - set the token value in action secret KODI_SUBMITTER_TOKEN https://github.com/thomas-ernest/plugin.video.arteplussept/settings/secrets/actions
+    - Re-run the failing job "Kodi Addon-Submitter"

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you are having issues with the add-on, you can open a issue and join your log
 
 ## Releasing
 
-### Releasing part on contributo's host
+### Releasing part on contributor's host
 
 Steps to be followed by a contributor to create a release.
 

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------
+# Method: ask_next_release_version
+# Get current version from addon.xml and ask for next release version
+# based on semantic versioning: major / minor / bugfix.
+# Enable override of the incremented version.
+# ---------------------------------------------------------
+ask_next_release_version() {
+    local CURRENT_VERSION
+    CURRENT_VERSION=$(grep -oP '<addon\b[^>]*\bversion="\K[0-9]+\.[0-9]+\.[0-9]+' addon.xml)
+
+    local MAJOR MINOR BUGFIX
+    MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
+    MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+    BUGFIX=$(echo "$CURRENT_VERSION" | cut -d. -f3)
+
+    echo "Current version is $CURRENT_VERSION"
+    echo "Choose semantic version bump:"
+    echo "  1) major"
+    echo "  2) minor"
+    echo "  3) bugfix (default)"
+    read -p "Select (1/2/3): " CHOICE
+
+    case "$CHOICE" in
+        1)
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            BUGFIX=0
+            ;;
+        2)
+            MINOR=$((MINOR + 1))
+            BUGFIX=0
+            ;;
+        *)
+            BUGFIX=$((BUGFIX + 1))
+            ;;
+    esac
+
+    local PRESET_VERSION
+    PRESET_VERSION="${MAJOR}.${MINOR}.${BUGFIX}"
+    # Allow override
+    read -p "Enter the next release version (press ENTER to accept $PRESET_VERSION): " VERSION
+    VERSION=${VERSION:-$PRESET_VERSION}
+    export VERSION
+    echo "Next release version is $VERSION"
+}
+
+xml_escape() {
+    printf "%s" "$1" | sed \
+        -e 's/&/\&amp;/g' \
+        -e 's/</\&lt;/g' \
+        -e 's/>/\&gt;/g' \
+        -e 's/"/\&quot;/g'
+}
+
+# ---------------------------------------------------------
+# Method: ask_next_release_notes
+# Asks for multi-line release notes an ensures it is below 1500 characters
+# Uses editor directly (nano or $EDITOR)
+# ---------------------------------------------------------
+ask_next_release_notes() {
+    local TMPFILE
+    TMPFILE=$(mktemp)
+
+    echo "Enter release notes below 1500 characters :"
+    ${EDITOR:-nano} "$TMPFILE"
+
+    while true; do
+        NOTES=$(xml_escape "$(cat "$TMPFILE")")
+        local NOTES_LENGTH=${#NOTES}
+
+        if [ "$NOTES_LENGTH" -le 1500 ]; then
+            # Next release notes are valid, return them
+            export NOTES
+            return
+        fi
+
+        echo "WARNING: Release notes length is $NOTES_LENGTH characters (after escape)."
+        echo "It exceeds Kodi's addon.xml <news> field limit of 1500 characters."
+        echo "Please edit the release notes to be under 1500 characters."
+
+        ${EDITOR:-nano} "$TMPFILE"
+    done
+}
+
+# ---------------------------------------------------------
+# Method: compute_current_date
+# Export DATE as YYYY-M-D (example: 2023-8-14)
+# ---------------------------------------------------------
+compute_current_date() {
+    local YEAR MONTH DAY
+
+    YEAR=$(date +%Y)
+    MONTH=$(date +%-m)   # no leading zero
+    DAY=$(date +%-d)     # no leading zero
+
+    export DATE="${YEAR}-${MONTH}-${DAY}"
+    echo "Current date is $DATE"
+}
+
+
+echo "=== Create a new release for Kodi extension Arte+7 ==="
+
+# ---------------------------------------------------------
+# Ensure we are on master branch
+# ---------------------------------------------------------
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "master" ]; then
+    echo "ERROR: Releases must be created from the master branch."
+    echo "Current branch: $CURRENT_BRANCH"
+    exit 1
+fi
+
+# ---------------------------------------------------------
+# Parse arguments (only --no-push supported)
+# ---------------------------------------------------------
+NO_PUSH=false
+if [ "$1" == "--no-push" ]; then
+    NO_PUSH=true
+    echo "[NO-PUSH MODE] Commit and tag created locally but NOT pushed"
+fi
+
+# ---------------------------------------------------------
+# Run commands from extension root directory
+# ---------------------------------------------------------
+SCRIPT_DIR=$(dirname "$0")
+cd "$SCRIPT_DIR/.." || exit 1
+
+# ---------------------------------------------------------
+#  Ask for next version and release notes
+# ---------------------------------------------------------
+compute_current_date
+ask_next_release_version
+ask_next_release_notes
+
+echo "=== Updating addon.xml version attribute and <news> field ==="
+sed -i "s/version=\"[^\"]*\"/version=\"$VERSION\"/" addon.xml
+ADDON_NEWS="<news>${VERSION} (${DATE})
+${NOTES}</news>"
+awk -v news="$ADDON_NEWS" '
+    BEGIN { innews=0 }
+    /<news>/ { print news; innews=1; next }
+    /<\/news>/ { innews=0; next }
+    !innews { print }
+' addon.xml > addon.xml.tmp
+mv addon.xml.tmp addon.xml
+
+echo "=== Updating CHANGELOG.md ==="
+{
+    echo "## v$VERSION ($DATE)"
+    echo ""
+    echo "$NOTES"
+    echo ""
+    cat CHANGELOG.md
+} > CHANGELOG.md.tmp
+mv CHANGELOG.md.tmp CHANGELOG.md
+
+echo "=== Creating commit ==="
+git add addon.xml CHANGELOG.md
+git commit -m "Bump version to $VERSION"
+
+echo "=== Creating annotated tag v$VERSION ==="
+git tag -a "v$VERSION" -m "$NOTES"
+if [ "$NO_PUSH" = true ]; then
+    echo "=== [NO-PUSH MODE] Commit and tag created locally but NOT pushed ==="
+else
+    echo "=== Pushing commit and tag to origin ==="
+    git push origin --tags
+fi
+
+echo "=== Release v$VERSION created successfully ==="


### PR DESCRIPTION
- Adapt process to create release in master instead of relying on a cactus branching strategy
- Document a troubleshooting of releasing CI with Kodi Add-on Submitter
- Automatize release creation on contributor's host with a BASH script