### PR TITLE
Improve authentication and add device auth flow for smart tv

### DIFF
--- a/plugin.video.arteplussept/addon.xml
+++ b/plugin.video.arteplussept/addon.xml
@@ -15,37 +15,37 @@
                 xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/xbmc/xbmc/master/addons/xbmc.addon/metadata.xsd">
         <!-- https://github.com/xbmc/xbmc/blob/master/addons/xbmc.addon/metadata.xsd -->
         <summary lang="en_GB">Arte +7</summary>
-        <description lang="fr_FR">
-Regardez les vidéos de Arte sur Kodi
-Dons: https://thomas-ernest.github.io/
-Bugs ou demandes: https://github.com/thomas-ernest/plugin.video.arteplussept/issues
-        </description>
         <description lang="de_DE">
-Arte-Videos auf Kodi ansehen
+Geniesse Arte-Videos auf Kodi.
 Spenden: https://thomas-ernest.github.io/
 Fehlerberichte oder Anfragen: https://github.com/thomas-ernest/plugin.video.arteplussept/issues
         </description>
         <description lang="en_GB">
-Watch Arte videos on Kodi
+Enjoy Arte videos on Kodi.
 Donations: https://thomas-ernest.github.io/
 Bugs or feature requests: https://github.com/thomas-ernest/plugin.video.arteplussept/issues
         </description>
+        <description lang="fr_FR">
+Profitez des vidéos d&apos;Arte sur Kodi.
+Dons: https://thomas-ernest.github.io/
+Bugs ou demandes: https://github.com/thomas-ernest/plugin.video.arteplussept/issues
+        </description>
         <description lang="it_IT">
-Guarda i video di Arte su Kodi
+Goditi i video di Arte su Kodi.
 Donazioni: https://thomas-ernest.github.io/
 Segnalazioni di bug o richieste: https://github.com/thomas-ernest/plugin.video.arteplussept/issues
         </description>
         <description lang="pl_PL">
-Oglądaj filmy Arte w Kodi
+Oglądaj filmy Arte w Kodi.
 Darowizny: https://thomas-ernest.github.io/
 Błędy lub prośby: https://github.com/thomas-ernest/plugin.video.arteplussept/issues
         </description>
         <description lang="ro_RO">
-Urmăriți videoclipuri Arte pe Kodi
+Bucură-te de videoclipuri Arte pe Kodi.
 Donații: https://thomas-ernest.github.io/
 Erori sau solicitări: https://github.com/thomas-ernest/plugin.video.arteplussept/issues
         </description>
-        <language>fr de en it pl ro</language>
+        <language>de en fr it pl ro</language>
         <platform>all</platform>
         <license>MIT</license>
         <website>https://thomas-ernest.github.io/</website>

--- a/plugin.video.arteplussept/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.de_de/strings.po
@@ -93,6 +93,22 @@ msgctxt "#30022"
 msgid "Password missing"
 msgstr "Passwort fehlen"
 
+msgctxt "#30046"
+msgid "Login with Smart TV code on another device"
+msgstr "Mit Smart-TV-Code auf einem anderen Gerät anmelden"
+
+msgctxt "#30047"
+msgid "Login with email & password"
+msgstr "Mit E-Mail-Adresse und Passwort anmelden"
+
+msgctxt "#30048"
+msgid "ARTE Smart TV Login"
+msgstr "ARTE Smart-TV-Anmeldung"
+
+msgctxt "#30049"
+msgid "Enter the code \"{user_code}\" at \"{verification_uri}\" on your mobile device or computer."
+msgstr "Geben Sie den Code \"{user_code}\" unter \"{verification_uri}\" auf Ihrem Mobilgerät oder Computer ein."
+
 
 msgctxt "#30023"
 msgid "Add to Arte favorites"

--- a/plugin.video.arteplussept/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.de_de/strings.po
@@ -200,3 +200,18 @@ msgstr "{label} - Dieses Program enthält Szenen, die für junge oder empfindsam
 msgctxt "#30060"
 msgid "Play from the start"
 msgstr "Ab Anfang spielen"
+
+
+msgctxt "#30061"
+msgid "Version {version} installed successfully"
+msgstr "Version {version} erfolgreich installiert"
+
+msgctxt "#30062"
+msgid ""
+"Enjoy Arte videos on Kodi with Arte+7 {version}.\n"
+"Donations: https://thomas-ernest.github.io/\"
+"Bugs or feature requests: https://github.com/thomas-ernest/plugin.video.arteplussept/issues"
+msgstr ""
+"Geniesse Arte-Videos auf Kodi mit Arte+7 {version}.\n"
+"Spenden: https://thomas-ernest.github.io/\n"
+"Fehlerberichte oder Anfragen: https://github.com/thomas-ernest/plugin.video.arteplussept/issues"

--- a/plugin.video.arteplussept/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.en_gb/strings.po
@@ -93,6 +93,22 @@ msgctxt "#30022"
 msgid "Password missing"
 msgstr ""
 
+msgctxt "#30046"
+msgid "Login with Smart TV code on another device"
+msgstr ""
+
+msgctxt "#30047"
+msgid "Login with email & password"
+msgstr ""
+
+msgctxt "#30048"
+msgid "ARTE Smart TV Login"
+msgstr ""
+
+msgctxt "#30049"
+msgid "Enter the code \"{user_code}\" at \"{verification_uri}\" on your mobile device or computer."
+msgstr ""
+
 
 msgctxt "#30023"
 msgid "Add to Arte favorites"

--- a/plugin.video.arteplussept/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.en_gb/strings.po
@@ -199,3 +199,15 @@ msgstr ""
 msgctxt "#30060"
 msgid "Play from the start"
 msgstr ""
+
+
+msgctxt "#30061"
+msgid "Version {version} installed successfully"
+msgstr ""
+
+msgctxt "#30062"
+msgid ""
+"Enjoy Arte videos on Kodi with Arte+7 {version}.\n"
+"Donations: https://thomas-ernest.github.io/\n"
+"Bugs or feature requests: https://github.com/thomas-ernest/plugin.video.arteplussept/issues"
+msgstr ""

--- a/plugin.video.arteplussept/resources/language/resource.language.fr_fr/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.fr_fr/strings.po
@@ -93,6 +93,22 @@ msgctxt "#30022"
 msgid "Password missing"
 msgstr "Mot de passe manquant"
 
+msgctxt "#30046"
+msgid "Login with Smart TV code on another device"
+msgstr "S'authentifier avec un code de la Smart TV sur un autre appareil"
+
+msgctxt "#30047"
+msgid "Login with email & password"
+msgstr "S'authentifier avec son email et son mot de passe"
+
+msgctxt "#30048"
+msgid "ARTE Smart TV Login"
+msgstr "Authentification ARTE Smart TV"
+
+msgctxt "#30049"
+msgid "Enter the code \"{user_code}\" at \"{verification_uri}\" on your mobile device or computer."
+msgstr "Veuillez saisir le code \"{user_code}\" à l'adresse \"{verification_uri}\" sur votre mobile ou votre ordinateur."
+
 
 msgctxt "#30023"
 msgid "Add to Arte favorites"

--- a/plugin.video.arteplussept/resources/language/resource.language.fr_fr/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.fr_fr/strings.po
@@ -200,3 +200,18 @@ msgstr "{label} - Ce programme comporte des scènes déconseillées a un public 
 msgctxt "#30060"
 msgid "Play from the start"
 msgstr "Lire du début"
+
+
+msgctxt "#30061"
+msgid "Version {version} installed successfully"
+msgstr "Version {version} installée avec succès"
+
+msgctxt "#30062"
+msgid ""
+"Enjoy Arte videos on Kodi with Arte+7 {version}.\n"
+"Donations: https://thomas-ernest.github.io/\n"
+"Bugs or feature requests: https://github.com/thomas-ernest/plugin.video.arteplussept/issues"
+msgstr ""
+"Profitez des vidéos d'Arte sur Kodi avec Arte+7 {version}.\n"
+"Dons: https://thomas-ernest.github.io/\n"
+"Bugs ou demandes: https://github.com/thomas-ernest/plugin.video.arteplussept/issues"

--- a/plugin.video.arteplussept/resources/language/resource.language.it_it/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.it_it/strings.po
@@ -93,6 +93,22 @@ msgctxt "#30022"
 msgid "Password missing"
 msgstr "Password mancanti"
 
+msgctxt "#30046"
+msgid "Login with Smart TV code on another device"
+msgstr "Accedi con il codice Smart TV su un altro dispositivo"
+
+msgctxt "#30047"
+msgid "Login with email & password"
+msgstr "Accedi con email e password"
+
+msgctxt "#30048"
+msgid "ARTE Smart TV Login"
+msgstr "Accesso a Smart TV ARTE"
+
+msgctxt "#30049"
+msgid "Enter the code \"{user_code}\" at \"{verification_uri}\" on your mobile device or computer."
+msgstr "Inserisci il codice \"{user_code}\" su \"{verification_uri}\" dal tuo dispositivo mobile o computer."
+
 
 msgctxt "#30023"
 msgid "Add to Arte favorites"

--- a/plugin.video.arteplussept/resources/language/resource.language.it_it/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.it_it/strings.po
@@ -201,3 +201,18 @@ msgstr "{label} - Questo programma contiene scene sconsigliate ad un pubblico gi
 msgctxt "#30060"
 msgid "Play from the start"
 msgstr "Gioca dall'inizio"
+
+
+msgctxt "#30061"
+msgid "Version {version} installed successfully"
+msgstr "Versione {version} installata correttamente"
+
+msgctxt "#30062"
+msgid ""
+"Enjoy Arte videos on Kodi with Arte+7 {version}.\n"
+"Donations: https://thomas-ernest.github.io/\n"
+"Bugs or feature requests: https://github.com/thomas-ernest/plugin.video.arteplussept/issues"
+msgstr ""
+"Goditi i video di Arte su Kodi con Arte+7 {version}.\n"
+"Donazioni: https://thomas-ernest.github.io/\n"
+"Segnalazioni di bug o richieste: https://github.com/thomas-ernest/plugin.video.arteplussept/issues"

--- a/plugin.video.arteplussept/resources/language/resource.language.pl_pl/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.pl_pl/strings.po
@@ -93,6 +93,22 @@ msgctxt "#30022"
 msgid "Password missing"
 msgstr "Brak hasła"
 
+msgctxt "#30046"
+msgid "Login with Smart TV code on another device"
+msgstr „Zaloguj się przy użyciu kodu Smart TV na innym urządzeniu”
+
+msgctxt "#30047"
+msgid "Login with email & password"
+msgstr "Zaloguj się za pomocą adresu e-mail i hasła"
+
+msgctxt "#30048"
+msgid "ARTE Smart TV Login"
+msgstr "Logowanie do telewizora ARTE Smart TV"
+
+msgctxt "#30049"
+msgid "Enter the code \"{user_code}\" at \"{verification_uri}\" on your mobile device or computer."
+msgstr "Wprowadź kod \"{user_code}\" w adresie \"{verification_uri}\" na urządzeniu mobilnym lub komputerze."
+
 
 msgctxt "#30023"
 msgid "Add to Arte favorites"

--- a/plugin.video.arteplussept/resources/language/resource.language.pl_pl/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.pl_pl/strings.po
@@ -200,3 +200,18 @@ msgstr "{label} - Ten program zawiera sceny, które nie są odpowiednie dla mło
 msgctxt "#30060"
 msgid "Play from the start"
 msgstr "Odtwórz od początku"
+
+
+msgctxt "#30061"
+msgid "Version {version} installed successfully"
+msgstr "Wersja {version} została pomyślnie zainstalowana"
+
+msgctxt "#30062"
+msgid ""
+"Enjoy Arte videos on Kodi with Arte+7 {version}.\n"
+"Donations: https://thomas-ernest.github.io/\n"
+"Bugs or feature requests: https://github.com/thomas-ernest/plugin.video.arteplussept/issues"
+msgstr ""
+"Oglądaj filmy Arte w Kodi z Arte+7 {version}.\n"
+"Darowizny: https://thomas-ernest.github.io/\n"
+"Błędy lub prośby: https://github.com/thomas-ernest/plugin.video.arteplussept/issues"

--- a/plugin.video.arteplussept/resources/language/resource.language.ro_ro/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.ro_ro/strings.po
@@ -93,6 +93,22 @@ msgctxt "#30022"
 msgid "Password missing"
 msgstr "Parolă lipsă"
 
+msgctxt "#30046"
+msgid "Login with Smart TV code on another device"
+msgstr "Autentificare cu codul Smart TV pe alt dispozitiv"
+
+msgctxt "#30047"
+msgid "Login with email & password"
+msgstr "Autentificare cu adresa de e-mail și parola"
+
+msgctxt "#30048"
+msgid "ARTE Smart TV Login"
+msgstr "Autentificare ARTE Smart TV"
+
+msgctxt "#30049"
+msgid "Enter the code \"{user_code}\" at \"{verification_uri}\" on your mobile device or computer."
+msgstr "Introduceți codul \"{user_code}\" la \"{verification_uri}\" de pe dispozitivul mobil sau de pe computer."
+
 
 msgctxt "#30023"
 msgid "Add to Arte favorites"

--- a/plugin.video.arteplussept/resources/language/resource.language.ro_ro/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.ro_ro/strings.po
@@ -200,3 +200,18 @@ msgstr "{label} - Programul conține scene care nu sunt potrivite pentru oamenii
 msgctxt "#30060"
 msgid "Play from the start"
 msgstr "Joacă de la început"
+
+
+msgctxt "#30061"
+msgid "Version {version} installed successfully"
+msgstr "Versiune {version} instalată cu succes"
+
+msgctxt "#30062"
+msgid ""
+"Enjoy Arte videos on Kodi with Arte+7 {version}.\n"
+"Donations: https://thomas-ernest.github.io/\n"
+"Bugs or feature requests: https://github.com/thomas-ernest/plugin.video.arteplussept/issues"
+msgstr ""
+"Bucură-te de videoclipuri Arte pe Kodi cu Arte+7 {version}.\n"
+"Donații: https://thomas-ernest.github.io/\n"
+"Erori sau solicitări: https://github.com/thomas-ernest/plugin.video.arteplussept/issues"

--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -92,7 +92,7 @@ _COOKIES = {
 
 _ARTETV_ID_URL = 'https://id.arte.tv/auth/realms/myarte-prod/protocol/openid-connect'
 DEVICE_AUTH_URL = f"{_ARTETV_ID_URL}/auth/device"
-TOKEN_URL = f"{_ARTETV_ID_URL}/token"
+DEVICETOKEN_URL = f"{_ARTETV_ID_URL}/token"
 REVOKE_URL = f"{_ARTETV_ID_URL}/revoke"
 SMART_TV_CLIENT_ID = 'smart-tv'
 
@@ -381,7 +381,7 @@ def authenticate_in_arte(plugin, username='', password='', headers=None):
     try:
         # https://requests.readthedocs.io/en/latest/
         reply = requests.post(url, data=token_data, headers=headers, timeout=10)
-        logger.log_json(reply, 'artetv_auth')
+        logger.log_json(reply, 'artetv_auth_password')
     except requests.exceptions.ConnectionError as err:
         # unable to auth. e.g.
         # HTTPSConnectionPool(host='api.arte.tv', port=443):
@@ -395,63 +395,9 @@ def authenticate_in_arte(plugin, username='', password='', headers=None):
     return reply.json(object_pairs_hook=OrderedDict)
 
 
-def persist_token_in_arte(plugin, tokens, headers=None):
-    """Calls the sequence of 2 services to be able to reuse authentication token
-    Return True, if token is persisted, False otherwise.
-    Notify the user with a warning if persistance failed.
-    """
-    if headers is None:
-        headers = ARTETV_HEADERS
-    # set client to web, because with tv get error client_invalid, error Client not authorized
-    headers['client'] = 'web'
-
-    # step 1/2 : get additional cookies for step 2.
-    url = _ARTETV_AUTH_URL + ARTETV_ENDPOINTS['custom_token']
-    params = {
-        'shouldValidateAnonymous': False,
-        'token': tokens['access_token'],
-        'apikey': _API_KEY,
-        'isrememberme': True
-    }
-    error = None
-    cstm_tkn = None
-    try:
-        cstm_tkn = requests.get(url, params=params, headers=headers, cookies=_COOKIES, timeout=10)
-        logger.log_json(cstm_tkn, 'artetv_customtoken')
-    except requests.exceptions.ConnectionError as err:
-        error = err
-    if error or not cstm_tkn or cstm_tkn.status_code != 200:
-        err_dtls = str(error) if error else (cstm_tkn.text if cstm_tkn is not None else '')
-        xbmc.log(
-            f"Unable to persist Arte TV token {tokens['access_token']}. Step 1/2: {err_dtls}",
-            level=xbmc.LOGERROR)
-        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='warning')
-        return False
-
-    # step 2/2 : persist / remember token so that it can be reused
-    url = _ARTETV_AUTH_URL + ARTETV_ENDPOINTS['login']
-    params = {'shouldValidateAnonymous': 'false', 'apikey': _API_KEY}
-    cookies = hof.merge_dicts(_COOKIES, cstm_tkn.cookies)
-    login = None
-    try:
-        login = requests.get(url, params=params, headers=headers, cookies=cookies, timeout=10)
-        logger.log_json(login, 'artetv_login')
-    except requests.exceptions.ConnectionError as err:
-        error = err
-    if error or not login or login.status_code != 200:
-        err_dtls = str(error) if error else (login.text if login is not None else '')
-        xbmc.log(
-            f"Unable to persist Arte TV token {tokens['access_token']}. Step 2/2: {err_dtls}",
-            level=xbmc.LOGERROR)
-        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='warning')
-        return False
-
-    return True
-
-
 def device_authorization_request():
     """
-    Step 1 of ARTE Smart-TV Device Flow:
+    Step 1 of ARTE Smart TV Device Flow:
     Request device_code + user_code from Keycloak.
     Returns dict or None.
     """
@@ -466,6 +412,7 @@ def device_authorization_request():
         }
 
         resp = requests.post(DEVICE_AUTH_URL, data=payload, headers=headers, timeout=10)
+        logger.log_json(resp, 'artetv_deviceauth')
         if resp.status_code != 200:
             xbmc.log(f"Device authorization failed: HTTP {resp.status_code}", level=xbmc.LOGERROR)
             return None
@@ -480,7 +427,7 @@ def device_authorization_request():
 
 def device_token_request(device_code):
     """
-    Step 2 of ARTE Smart-TV Device Flow:
+    Step 2 of ARTE Smart TV Device Flow:
     Poll token endpoint using device_code.
     Returns dict containing either:
     - access_token (success)
@@ -497,7 +444,8 @@ def device_token_request(device_code):
             "Content-Type": "application/x-www-form-urlencoded"
         }
 
-        resp = requests.post(TOKEN_URL, data=payload, headers=headers, timeout=10)
+        resp = requests.post(DEVICETOKEN_URL, data=payload, headers=headers, timeout=10)
+        logger.log_json(resp, 'artetv_auth_devicetoken')
         return resp.json()
 
     # pylint: disable=broad-except
@@ -508,7 +456,7 @@ def device_token_request(device_code):
 
 def revoke_token(token):
     """
-    Revoke ARTE OAuth2 token (refresh_token recommended).
+    Revoke ARTE OAuth2 token (refresh_token recommended with auto-cascade access token).
     Returns True on success, False otherwise.
     """
     try:
@@ -523,6 +471,7 @@ def revoke_token(token):
         }
 
         resp = requests.post(REVOKE_URL, data=payload, headers=headers, timeout=10)
+        logger.log_json(resp, 'artetv_revoketoken')
 
         # Keycloak returns 200 even if token was already invalid
         return resp.status_code == 200

--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -90,6 +90,12 @@ _COOKIES = {
     'TC_PRIVACY_CENTER': None
 }
 
+_ARTETV_ID_URL = 'https://id.arte.tv/auth/realms/myarte-prod/protocol/openid-connect'
+DEVICE_AUTH_URL = f"{_ARTETV_ID_URL}/auth/device"
+TOKEN_URL = f"{_ARTETV_ID_URL}/token"
+REVOKE_URL = f"{_ARTETV_ID_URL}/revoke"
+SMART_TV_CLIENT_ID = 'smart-tv'
+
 
 def get_favorites(lang, tkn, page_idx, page_size=50):
     """Retrieve favorites from a personal account."""
@@ -353,23 +359,6 @@ def _add_auth_token(tkn, hdrs):
     return headers
 
 
-def get_and_persist_token_in_arte(plugin, username, password):
-    """Log in user thanks to his/her settings and get a bearer token.
-    Return None if:
-        - any parameter is empty
-        - silenty if both parameters are empty
-        - with a notification if one is not empty
-        - connection to arte tv failed"""
-
-    tokens = authenticate_in_arte(plugin, username, password)
-    # exit if authentication failed
-    if not tokens:
-        return None
-
-    # return persisted or unpersisted token anyway
-    return tokens
-
-
 def authenticate_in_arte(plugin, username='', password='', headers=None):
     """Return None if authentication failed and display an error notification
     Return arte reply with access and refresh tokens if authentication was successfull
@@ -458,3 +447,87 @@ def persist_token_in_arte(plugin, tokens, headers=None):
         return False
 
     return True
+
+
+def device_authorization_request():
+    """
+    Step 1 of ARTE Smart-TV Device Flow:
+    Request device_code + user_code from Keycloak.
+    Returns dict or None.
+    """
+    try:
+        payload = {
+            "client_id": SMART_TV_CLIENT_ID,
+            "scope": "openid"
+        }
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded"
+        }
+
+        resp = requests.post(DEVICE_AUTH_URL, data=payload, headers=headers, timeout=10)
+        if resp.status_code != 200:
+            xbmc.log(f"Device authorization failed: HTTP {resp.status_code}", level=xbmc.LOGERROR)
+            return None
+
+        return resp.json()
+
+    # pylint: disable=broad-except
+    except Exception as e:
+        xbmc.log(f"Device authorization exception: {e}", level=xbmc.LOGERROR)
+        return None
+
+
+def device_token_request(device_code):
+    """
+    Step 2 of ARTE Smart-TV Device Flow:
+    Poll token endpoint using device_code.
+    Returns dict containing either:
+    - access_token (success)
+    - error (authorization_pending, slow_down, access_denied, expired_token)
+    """
+    try:
+        payload = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": device_code,
+            "client_id": SMART_TV_CLIENT_ID
+        }
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded"
+        }
+
+        resp = requests.post(TOKEN_URL, data=payload, headers=headers, timeout=10)
+        return resp.json()
+
+    # pylint: disable=broad-except
+    except Exception as e:
+        xbmc.log(f"Device token polling exception: {e}", level=xbmc.LOGERROR)
+        return {"error": "exception"}
+
+
+def revoke_token(token):
+    """
+    Revoke ARTE OAuth2 token (refresh_token recommended).
+    Returns True on success, False otherwise.
+    """
+    try:
+        payload = {
+            "client_id": SMART_TV_CLIENT_ID,
+            "token": token,
+            "token_type_hint": "refresh_token"
+        }
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded"
+        }
+
+        resp = requests.post(REVOKE_URL, data=payload, headers=headers, timeout=10)
+
+        # Keycloak returns 200 even if token was already invalid
+        return resp.status_code == 200
+
+    # pylint: disable=broad-except
+    except Exception as e:
+        xbmc.log(f"Token revocation exception: {e}", level=xbmc.LOGERROR)
+        return False

--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -50,6 +50,9 @@ ARTETV_ENDPOINTS = {
     # PATCH empty payload
     # needs token in authorization header
     'purge_last_viewed': '/sso/v3/lastvieweds/purge',
+    # GET personal user data (email, firstName, lastName, etc.)
+    # needs token in authorization header
+    'personal_data': '/sso/v3/me',
     # program_id can be 103520-000-A or LIVE
     'player': '/player/v2/config/{lang}/{program_id}',
     'program': '/emac/v4/{lang}/web/programs/{program_id}',
@@ -69,8 +72,6 @@ ARTETV_ENDPOINTS = {
     # date=2023-01-17
     # 'guide_tv': '/emac/v3/{lang}/{client}/pages/TV_GUIDE/?day={DATE}',
     # auth api
-    'custom_token': '/setCustomToken',
-    # auth api
     'login': '/login',
 }
 ARTETV_HEADERS = {
@@ -81,13 +82,6 @@ ARTETV_HEADERS = {
     # prefer client tv over web so that Arte adapt content to tv limiting links for instance
     'client': 'tv',
     'accept': 'application/json'
-}
-_API_KEY = '97598990-f0af-427b-893e-9da348d9f5a6'
-_COOKIES = {
-    'TCPID': '123261154911117061452',
-    # pylint: disable=line-too-long
-    'TC_PRIVACY': '1%40031%7C29%7C3445%40%40%401677322453596%2C1677322453596%2C1711018453596%40',
-    'TC_PRIVACY_CENTER': None
 }
 
 _ARTETV_ID_URL = 'https://id.arte.tv/auth/realms/myarte-prod/protocol/openid-connect'
@@ -191,6 +185,19 @@ def purge_last_viewed(tkn):
     reply = requests.patch(url, data={}, headers=headers, timeout=10)
     logger.log_json(reply, 'artetv_purgelastviewed')
     return reply.status_code
+
+
+def get_personal_data(tkn):
+    """
+    Retrieve personal user data (email, firstName, lastName, etc.) from Arte API.
+    Requires authenticated token.
+    Returns the user data dict from API response or None if request fails.
+    """
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['personal_data']
+    reply = _load_json_personal_content('artetv_getpersonaldata', url, tkn)
+    if reply is not None and isinstance(reply.get('data'), list) and len(reply.get('data', [])) > 0:
+        return reply['data'][0]
+    return None
 
 
 def player_video(lang, program_id):

--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -93,7 +93,6 @@ _COOKIES = {
 _ARTETV_ID_URL = 'https://id.arte.tv/auth/realms/myarte-prod/protocol/openid-connect'
 DEVICE_AUTH_URL = f"{_ARTETV_ID_URL}/auth/device"
 DEVICETOKEN_URL = f"{_ARTETV_ID_URL}/token"
-REVOKE_URL = f"{_ARTETV_ID_URL}/revoke"
 SMART_TV_CLIENT_ID = 'smart-tv'
 
 
@@ -452,31 +451,3 @@ def device_token_request(device_code):
     except Exception as e:
         xbmc.log(f"Device token polling exception: {e}", level=xbmc.LOGERROR)
         return {"error": "exception"}
-
-
-def revoke_token(token):
-    """
-    Revoke ARTE OAuth2 token (refresh_token recommended with auto-cascade access token).
-    Returns True on success, False otherwise.
-    """
-    try:
-        payload = {
-            "client_id": SMART_TV_CLIENT_ID,
-            "token": token,
-            "token_type_hint": "refresh_token"
-        }
-
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded"
-        }
-
-        resp = requests.post(REVOKE_URL, data=payload, headers=headers, timeout=10)
-        logger.log_json(resp, 'artetv_revoketoken')
-
-        # Keycloak returns 200 even if token was already invalid
-        return resp.status_code == 200
-
-    # pylint: disable=broad-except
-    except Exception as e:
-        xbmc.log(f"Token revocation exception: {e}", level=xbmc.LOGERROR)
-        return False

--- a/plugin.video.arteplussept/resources/lib/plugin.py
+++ b/plugin.video.arteplussept/resources/lib/plugin.py
@@ -1,5 +1,7 @@
 """Main module for Kodi add-on plugin.video.arteplussept"""
 
+import xbmcaddon
+import xbmcgui
 # pylint: disable=import-error
 from xbmcswift2 import Plugin
 # pylint: disable=import-error
@@ -25,7 +27,21 @@ settings = Settings(plugin)
 
 @plugin.route('/', name='index')
 def display_index():
-    """Display home menu"""
+    """
+    Display home menu. On every new version, display a dialog box
+    to remind users where to donate and report issues.
+    """
+    addon = xbmcaddon.Addon()
+    current_version = addon.getAddonInfo("version")
+    last_version = addon.getSetting("last_version_notified")
+
+    if last_version != current_version:
+        xbmcgui.Dialog().ok(
+            addon.getLocalizedString(30061).format(version=current_version),
+            addon.getLocalizedString(30062).format(version=current_version)
+        )
+        addon.setSetting("last_info_version", current_version)
+
     lst_itms = view.build_home_page(
         plugin, settings, plugin.get_storage('cached_categories', TTL=60))
     logger.log_xbmc(lst_itms, 'index')

--- a/plugin.video.arteplussept/resources/lib/plugin.py
+++ b/plugin.video.arteplussept/resources/lib/plugin.py
@@ -242,7 +242,7 @@ def display_search_page(zone_id, page, query):
 @plugin.route('/user/login', name='user_login')
 def user_login():
     """Login user with email already set in settings by creating and persisting a token."""
-    return plugin.finish(succeeded=user.login(plugin, settings))
+    return plugin.finish(succeeded=user.login(plugin))
 
 
 @plugin.route('/user/logout', name='user_logout')

--- a/plugin.video.arteplussept/resources/lib/settings.py
+++ b/plugin.video.arteplussept/resources/lib/settings.py
@@ -28,8 +28,6 @@ class Settings:
         # Arte TV user name
         # defaults to empty string to return false with if not str
         self.username = plugin.get_setting(
-            'username') or ""
-        self.user_mail = plugin.get_setting(
             'user_email') or ""
         # Enable additional logs managed by plugin: API and display object traces
         self.loglevel = plugin.get_setting(

--- a/plugin.video.arteplussept/resources/lib/user.py
+++ b/plugin.video.arteplussept/resources/lib/user.py
@@ -21,15 +21,15 @@ def login(plugin, settings):
     Unified login entry point.
     User chooses between:
     - Password login
-    - Smart-TV Device login
+    - Smart TV Device login
     """
     erase_password_in_old_config(plugin)
 
     choice = xbmcgui.Dialog().select(
         plugin.addon.getLocalizedString(30057),
         [
-            "Login with Smart‑TV device code",
-            "Login with email & password"
+            plugin.addon.getLocalizedString(30046),
+            plugin.addon.getLocalizedString(30047)
         ]
     )
     if choice == 0:
@@ -40,7 +40,7 @@ def login(plugin, settings):
 
 
 # ---------------------------------------------------------------------------
-# PASSWORD LOGIN (existing logic, untouched)
+# PASSWORD LOGIN
 # ---------------------------------------------------------------------------
 
 def login_with_password(plugin, settings):
@@ -114,23 +114,21 @@ def get_user_password(plugin):
 
 
 # ---------------------------------------------------------------------------
-# SMART-TV DEVICE FLOW LOGIN (new)
+# SMART TV DEVICE FLOW LOGIN
 # ---------------------------------------------------------------------------
 
 def login_with_device_flow(plugin, settings):
     """
-    Smart-TV Device Authorization Flow:
+    Smart TV Device Authorization Flow:
     1. Request device_code + user_code
-    2. Show QR code + user_code to user and steps to authenticate on another device
+    2. Show instructions and code to authenticate on another device
     3. Poll token endpoint until success
     4. Store token
     """
-    xbmc.log("Starting ARTE Smart-TV device login", level=xbmc.LOGINFO)
-
     # Step 1 - request device_code
     device_info = api.device_authorization_request()
     if not device_info:
-        plugin.notify(msg="Device login failed: cannot contact ARTE", image='error')
+        plugin.notify(plugin.addon.getLocalizedString(30020), image='error')
         return False
 
     device_code = device_info["device_code"]
@@ -139,61 +137,33 @@ def login_with_device_flow(plugin, settings):
     # verification_uri_complete = device_info["verification_uri_complete"]
     interval = device_info.get("interval", 5)
 
-    # Step 2 - show QR code + user_code
-    show_device_login_dialog(user_code, verification_uri)
+    # Step 2 - show instructions and code to authenticate on another device
+    show_device_login_dialog(plugin, user_code, verification_uri)
 
     # Step 3 - poll token endpoint
     tokens = poll_device_token(device_code, interval)
     if tokens is None:
-        plugin.notify(msg="Device login failed", image='error')
+        plugin.notify(plugin.addon.getLocalizedString(30020), image='error')
         return False
 
     # Step 4 - store token
     usr = settings.username
     set_cached_token(plugin, usr, tokens)
     update_settings_state(plugin, usr)
-    # TODO set the right notification
     msg = plugin.addon.getLocalizedString(30017).format(user=usr)
     plugin.notify(msg=msg, image='info')
     return True
 
 
-def show_device_login_dialog(user_code, verification_uri):
+def show_device_login_dialog(plugin, user_code, verification_uri):
     """
-    Display QR code + user_code in a Kodi dialog.
+    Display instructions and user code to authenticate on another device
     """
     xbmcgui.Dialog().ok(
-        "ARTE Smart‑TV Login",
-        f"Enter the code {user_code} at {verification_uri} from your mobile device or computer."
+        plugin.addon.getLocalizedString(30048),
+        plugin.addon.getLocalizedString(30049).format(
+            user_code=user_code, verification_uri=verification_uri)
     )
-
-    # qr = qrcode.make(verification_uri_complete)
-    # qr_path = xbmcmixin.temp_fn("arte_tvlogin_qr.png")
-    # qr.save(stream=qr_path, format="PNG")
-    # # buffer = BytesIO()
-    # # with open(qr_path, "wb") as qr_file:
-    # #     qr_file.write(buffer.getvalue())
-    # show_qr_window(qr_path, user_code, verification_uri)
-
-
-# def show_qr_window(qr_path, user_code, verification_uri):
-#     """
-#     Display a window with QR code and information to authenticate.
-#     """
-#     win = xbmcgui.WindowDialog()
-
-#     lbl = xbmcgui.ControlLabel(
-#         200, 720, 600, 40,
-#         f"Enter the code [b]{user_code}[/b] at [{verification_uri}] on your mobile.\n\
-#         Or scan the QR code.",
-#         textColor="white", alignment=2)
-#     img = xbmcgui.ControlImage(200, 100, 600, 600, qr_path)
-
-#     win.addControl(img)
-#     win.addControl(lbl)
-
-#     win.doModal()
-#     del win
 
 
 def poll_device_token(device_code, interval):
@@ -226,7 +196,7 @@ def poll_device_token(device_code, interval):
 
 
 # ---------------------------------------------------------------------------
-# EXISTING UTILITIES (unchanged)
+# LOGOUT
 # ---------------------------------------------------------------------------
 
 
@@ -250,6 +220,10 @@ def logout(plugin, settings):
     update_settings_state(plugin, '')
     plugin.notify(msg=plugin.addon.getLocalizedString(30018), image='info')
     return True
+
+# ---------------------------------------------------------------------------
+# EXISTING UTILITIES
+# ---------------------------------------------------------------------------
 
 
 def update_settings_state(plugin, email):

--- a/plugin.video.arteplussept/resources/lib/user.py
+++ b/plugin.video.arteplussept/resources/lib/user.py
@@ -204,16 +204,8 @@ def logout(plugin, settings):
     """Delete user token and reset settings state"""
     erase_password_in_old_config(plugin)
 
-    usr = settings.username
-    cached_token = get_cached_token(plugin, usr, silent=True)
+    # Possible improve - revoke token remotely or logout
 
-    # Revoke refresh token if available - clear token remotely
-    if cached_token and "refresh_token" in cached_token:
-        refresh_token = cached_token["refresh_token"]
-        if api.revoke_token(refresh_token):
-            xbmc.log("ARTE token successfully revoked", level=xbmc.LOGINFO)
-        else:
-            xbmc.log("Failed to revoke ARTE token", level=xbmc.LOGWARNING)
     # clear token locally
     set_cached_token(plugin, settings.username, '')
     clear_cached_tokens(plugin)

--- a/plugin.video.arteplussept/resources/lib/user.py
+++ b/plugin.video.arteplussept/resources/lib/user.py
@@ -16,12 +16,12 @@ _STORAGE_KEY = 'token'
 _TTL = 30*24*60
 
 
-def login(plugin, settings):
+def login(plugin):
     """
     Unified login entry point.
     User chooses between:
-    - Password login
     - Smart TV Device login
+    - Password login
     """
     erase_password_in_old_config(plugin)
 
@@ -33,9 +33,9 @@ def login(plugin, settings):
         ]
     )
     if choice == 0:
-        return login_with_device_flow(plugin, settings)
+        return login_with_device_flow(plugin)
     if choice == 1:
-        return login_with_password(plugin, settings)
+        return login_with_password(plugin)
     return False
 
 
@@ -43,46 +43,31 @@ def login(plugin, settings):
 # PASSWORD LOGIN
 # ---------------------------------------------------------------------------
 
-def login_with_password(plugin, settings):
+def login_with_password(plugin):
     """
-    Get user password from UI, create a token with Arte API, persist it in storage
+    Get user email and password from UI, create a token with Arte API, persist it in storage
     and update settings state to show user is logged in.
     """
-    # ensure user to log in is identified
-    usr = settings.username
-    if not usr:
-        msg = f"{plugin.addon.getLocalizedString(30020)} : {plugin.addon.getLocalizedString(30021)}"
-        plugin.notify(msg=msg, image='error')
+    # get email from user
+    email = get_user_email(plugin)
+    if not email:
+        xbmc.log('Authentication aborted by user - no email entered', level=xbmc.LOGWARNING)
+        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='error')
         return False
 
-    # ensure no user is not logged in
-    loggedin_usr = settings.user_email
-    tkn_data = get_cached_token(plugin, usr, True)
-    if len(loggedin_usr) > 0 and tkn_data:
-        xbmc.log(
-            f"\"{loggedin_usr}\" already authenticated : {tkn_data['access_token']}",
-            level=xbmc.LOGINFO)
-        # notify user that current token might be replaced
-        accept_to_replace = xbmcgui.Dialog().yesno(
-            plugin.addon.getLocalizedString(30015),
-            plugin.addon.getLocalizedString(30016).format(new_user=usr, old_user=loggedin_usr),
-            autoclose=10000
-        )
-        # user didn't accept replacement, so leave
-        if not accept_to_replace:
-            xbmc.log('Authentication aborted by user - keep initial token', level=xbmc.LOGWARNING)
-            return False
+    # if user already logged in with this email and token is valid, confirm s/he wants to override
+    if not want_to_continue_or_override_auth(plugin, email):
+        return False
 
     # get password
     pwd = get_user_password(plugin)
     if not pwd:
         xbmc.log('Authentication aborted by user - no password entered', level=xbmc.LOGWARNING)
-        msg = f"{plugin.addon.getLocalizedString(30020)} : {plugin.addon.getLocalizedString(30022)}"
-        plugin.notify(msg=msg, image='error')
+        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='error')
         return False
 
     # get token for user and password
-    tokens = api.authenticate_in_arte(plugin, usr, pwd)
+    tokens = api.authenticate_in_arte(plugin, email, pwd)
     if tokens is None:
         xbmc.log('Authentication failed in arte', level=xbmc.LOGERROR)
         msg = f"{plugin.addon.getLocalizedString(30020)}"
@@ -90,10 +75,52 @@ def login_with_password(plugin, settings):
         return False
 
     # store token
-    set_cached_token(plugin, usr, tokens)
-    update_settings_state(plugin, usr)
-    msg = plugin.addon.getLocalizedString(30017).format(user=usr)
+    set_cached_token(plugin, email, tokens)
+    set_auth_user_settings(plugin, email)
+    msg = plugin.addon.getLocalizedString(30017).format(user=email)
     plugin.notify(msg=msg, image='info')
+    return True
+
+
+def get_user_email(plugin):
+    """
+    Display a keyboard to get user email.
+    Return None if user didn't enter an email or close the UI.
+    """
+    user_email = ''
+    keyboard = xbmc.Keyboard(user_email, plugin.addon.getLocalizedString(30019), False)
+    keyboard.doModal()
+    if keyboard.isConfirmed() is False:
+        return None
+    user_email = keyboard.getText()
+    if len(user_email) == 0:
+        return None
+    return user_email
+
+
+def want_to_continue_or_override_auth(plugin, new_user):
+    """
+    If user already authenticated (with a valid token and) with same email,
+    confirm that s/he wants to override her/his token.
+    Return False if user confirms replacement, True otherwise.
+    Return true, if token is invalid or emails are different.
+    """
+    # assuming that new user's email and old user's email are the same,
+    # since token can be retrieved/is indexed by email.
+    current_tkn = get_cached_token(plugin, new_user, True)
+    if current_tkn:
+        xbmc.log(f"\"{new_user}\" already authenticated : {current_tkn['access_token']}")
+        # notify user that current token might be replaced
+        accept_to_replace = xbmcgui.Dialog().yesno(
+            plugin.addon.getLocalizedString(30015),
+            # old_user=new_user highlight the unsual situation
+            plugin.addon.getLocalizedString(30016).format(new_user=new_user, old_user=new_user),
+            autoclose=10000
+        )
+        # user didn't accept replacement, so leave
+        if not accept_to_replace:
+            xbmc.log('Authentication aborted by user - keep initial token', level=xbmc.LOGWARNING)
+            return False
     return True
 
 
@@ -117,13 +144,14 @@ def get_user_password(plugin):
 # SMART TV DEVICE FLOW LOGIN
 # ---------------------------------------------------------------------------
 
-def login_with_device_flow(plugin, settings):
+def login_with_device_flow(plugin):
     """
     Smart TV Device Authorization Flow:
     1. Request device_code + user_code
     2. Show instructions and code to authenticate on another device
     3. Poll token endpoint until success
-    4. Store token
+    4. Retrieve email from personal data endpoint
+    5. Store token
     """
     # Step 1 - request device_code
     device_info = api.device_authorization_request()
@@ -146,11 +174,23 @@ def login_with_device_flow(plugin, settings):
         plugin.notify(plugin.addon.getLocalizedString(30020), image='error')
         return False
 
-    # Step 4 - store token
-    usr = settings.username
-    set_cached_token(plugin, usr, tokens)
-    update_settings_state(plugin, usr)
-    msg = plugin.addon.getLocalizedString(30017).format(user=usr)
+    # Step 4 - retrieve email from personal data endpoint
+    user_data = api.get_personal_data(tokens)
+    if user_data is None:
+        xbmc.log('Failed to retrieve personal data from Arte API', level=xbmc.LOGERROR)
+        plugin.notify(plugin.addon.getLocalizedString(30020), image='error')
+        return False
+
+    email = user_data.get('email')
+    if not email:
+        xbmc.log('Email not found in personal data from Arte API', level=xbmc.LOGERROR)
+        plugin.notify(plugin.addon.getLocalizedString(30020), image='error')
+        return False
+
+    # Step 5 - store token
+    set_cached_token(plugin, email, tokens)
+    set_auth_user_settings(plugin, email)
+    msg = plugin.addon.getLocalizedString(30017).format(user=email)
     plugin.notify(msg=msg, image='info')
     return True
 
@@ -209,7 +249,7 @@ def logout(plugin, settings):
     # clear token locally
     set_cached_token(plugin, settings.username, '')
     clear_cached_tokens(plugin)
-    update_settings_state(plugin, '')
+    set_auth_user_settings(plugin, '')
     plugin.notify(msg=plugin.addon.getLocalizedString(30018), image='info')
     return True
 
@@ -218,7 +258,7 @@ def logout(plugin, settings):
 # ---------------------------------------------------------------------------
 
 
-def update_settings_state(plugin, email):
+def set_auth_user_settings(plugin, email):
     """Update setting state to know who belong the token to"""
     message = plugin.addon.getLocalizedString(30017).format(user=email)
     if email is None or len(email) <= 0:
@@ -261,4 +301,4 @@ def erase_password_in_old_config(plugin):
     to authenticate user.
     Deprecated since creation JUL2023, v1.3.0.
     """
-    return plugin.set_setting('password', '')
+    return plugin.set_setting('password', '') and plugin.set_setting('username', '')

--- a/plugin.video.arteplussept/resources/lib/user.py
+++ b/plugin.video.arteplussept/resources/lib/user.py
@@ -3,7 +3,7 @@ Manage Arte user content and state e.g. favorites and last vieweds.
 Manage settings and user interactions to create a token.
 Manage token in cache. Avoid storing password in settings, only token.
 """
-
+import time
 # pylint: disable=import-error
 from xbmcswift2 import xbmc
 from xbmcswift2 import xbmcgui
@@ -18,11 +18,36 @@ _TTL = 30*24*60
 
 def login(plugin, settings):
     """
-    Get user password from UI, create a token with Arte API, persist it in storage
-    and update settings state to show user is logged in.
+    Unified login entry point.
+    User chooses between:
+    - Password login
+    - Smart-TV Device login
     """
     erase_password_in_old_config(plugin)
 
+    choice = xbmcgui.Dialog().select(
+        plugin.addon.getLocalizedString(30057),
+        [
+            "Login with Smart‑TV device code",
+            "Login with email & password"
+        ]
+    )
+    if choice == 0:
+        return login_with_device_flow(plugin, settings)
+    if choice == 1:
+        return login_with_password(plugin, settings)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# PASSWORD LOGIN (existing logic, untouched)
+# ---------------------------------------------------------------------------
+
+def login_with_password(plugin, settings):
+    """
+    Get user password from UI, create a token with Arte API, persist it in storage
+    and update settings state to show user is logged in.
+    """
     # ensure user to log in is identified
     usr = settings.username
     if not usr:
@@ -35,7 +60,7 @@ def login(plugin, settings):
     tkn_data = get_cached_token(plugin, usr, True)
     if len(loggedin_usr) > 0 and tkn_data:
         xbmc.log(
-            f"\"{loggedin_usr}\" already authenticated to Arte TV : {tkn_data['access_token']}",
+            f"\"{loggedin_usr}\" already authenticated : {tkn_data['access_token']}",
             level=xbmc.LOGINFO)
         # notify user that current token might be replaced
         accept_to_replace = xbmcgui.Dialog().yesno(
@@ -57,7 +82,7 @@ def login(plugin, settings):
         return False
 
     # get token for user and password
-    tokens = api.get_and_persist_token_in_arte(plugin, usr, pwd)
+    tokens = api.authenticate_in_arte(plugin, usr, pwd)
     if tokens is None:
         xbmc.log('Authentication failed in arte', level=xbmc.LOGERROR)
         msg = f"{plugin.addon.getLocalizedString(30020)}"
@@ -88,14 +113,141 @@ def get_user_password(plugin):
     return user_password
 
 
+# ---------------------------------------------------------------------------
+# SMART-TV DEVICE FLOW LOGIN (new)
+# ---------------------------------------------------------------------------
+
+def login_with_device_flow(plugin, settings):
+    """
+    Smart-TV Device Authorization Flow:
+    1. Request device_code + user_code
+    2. Show QR code + user_code to user and steps to authenticate on another device
+    3. Poll token endpoint until success
+    4. Store token
+    """
+    xbmc.log("Starting ARTE Smart-TV device login", level=xbmc.LOGINFO)
+
+    # Step 1 - request device_code
+    device_info = api.device_authorization_request()
+    if not device_info:
+        plugin.notify(msg="Device login failed: cannot contact ARTE", image='error')
+        return False
+
+    device_code = device_info["device_code"]
+    user_code = device_info["user_code"]
+    verification_uri = device_info["verification_uri"]
+    # verification_uri_complete = device_info["verification_uri_complete"]
+    interval = device_info.get("interval", 5)
+
+    # Step 2 - show QR code + user_code
+    show_device_login_dialog(user_code, verification_uri)
+
+    # Step 3 - poll token endpoint
+    tokens = poll_device_token(device_code, interval)
+    if tokens is None:
+        plugin.notify(msg="Device login failed", image='error')
+        return False
+
+    # Step 4 - store token
+    usr = settings.username
+    set_cached_token(plugin, usr, tokens)
+    update_settings_state(plugin, usr)
+    # TODO set the right notification
+    msg = plugin.addon.getLocalizedString(30017).format(user=usr)
+    plugin.notify(msg=msg, image='info')
+    return True
+
+
+def show_device_login_dialog(user_code, verification_uri):
+    """
+    Display QR code + user_code in a Kodi dialog.
+    """
+    xbmcgui.Dialog().ok(
+        "ARTE Smart‑TV Login",
+        f"Enter the code {user_code} at {verification_uri} from your mobile device or computer."
+    )
+
+    # qr = qrcode.make(verification_uri_complete)
+    # qr_path = xbmcmixin.temp_fn("arte_tvlogin_qr.png")
+    # qr.save(stream=qr_path, format="PNG")
+    # # buffer = BytesIO()
+    # # with open(qr_path, "wb") as qr_file:
+    # #     qr_file.write(buffer.getvalue())
+    # show_qr_window(qr_path, user_code, verification_uri)
+
+
+# def show_qr_window(qr_path, user_code, verification_uri):
+#     """
+#     Display a window with QR code and information to authenticate.
+#     """
+#     win = xbmcgui.WindowDialog()
+
+#     lbl = xbmcgui.ControlLabel(
+#         200, 720, 600, 40,
+#         f"Enter the code [b]{user_code}[/b] at [{verification_uri}] on your mobile.\n\
+#         Or scan the QR code.",
+#         textColor="white", alignment=2)
+#     img = xbmcgui.ControlImage(200, 100, 600, 600, qr_path)
+
+#     win.addControl(img)
+#     win.addControl(lbl)
+
+#     win.doModal()
+#     del win
+
+
+def poll_device_token(device_code, interval):
+    """
+    Poll ARTE token endpoint until:
+    - authorization_pending
+    - slow_down
+    - success (returns tokens)
+    - error (returns None)
+    """
+    while True:
+        data = api.device_token_request(device_code)
+
+        if "access_token" in data:
+            return data
+
+        error = data.get("error")
+
+        if error == "authorization_pending":
+            time.sleep(interval)
+            continue
+
+        if error == "slow_down":
+            interval += 5
+            time.sleep(interval)
+            continue
+
+        xbmc.log(f"Device login error: {error}", level=xbmc.LOGERROR)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# EXISTING UTILITIES (unchanged)
+# ---------------------------------------------------------------------------
+
+
 def logout(plugin, settings):
     """Delete user token and reset settings state"""
     erase_password_in_old_config(plugin)
 
+    usr = settings.username
+    cached_token = get_cached_token(plugin, usr, silent=True)
+
+    # Revoke refresh token if available - clear token remotely
+    if cached_token and "refresh_token" in cached_token:
+        refresh_token = cached_token["refresh_token"]
+        if api.revoke_token(refresh_token):
+            xbmc.log("ARTE token successfully revoked", level=xbmc.LOGINFO)
+        else:
+            xbmc.log("Failed to revoke ARTE token", level=xbmc.LOGWARNING)
+    # clear token locally
     set_cached_token(plugin, settings.username, '')
     clear_cached_tokens(plugin)
     update_settings_state(plugin, '')
-
     plugin.notify(msg=plugin.addon.getLocalizedString(30018), image='info')
     return True
 

--- a/plugin.video.arteplussept/resources/settings.xml
+++ b/plugin.video.arteplussept/resources/settings.xml
@@ -30,10 +30,6 @@
 	<!-- Profile -->
 	<category label="30045">
 		<setting
-			id="username"
-			type="text"
-			label="30054" />
-		<setting
 			id="user_email"
 			type="text"
 			default=""


### PR DESCRIPTION
- New: Add auth with device flow  to simplify auth for Smart TV users
- New: Remind user where to donate or to report issues on new version of the extension
- NFR: Add logging of API communication related to auth.
- NFR: Clean-up code related to auth in api.py and user.py. Especially failing persistance mechanism.
