### PR TITLE
Fix next page navigation and error messages for non authenticated users

### DIFF
--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -304,6 +304,11 @@ def get_zone_page(lang, zone_id, page_idx):
     """
     Navigate in pages of a zone identified by zone_id.
     """
+    # fix "bug" in Arte TV API of doubled zone_id. Example of wrong value:
+    # a6f8c6d2-29d8-44e6-95f3-eec44d2fedaa_a6f8c6d2-29d8-44e6-95f3-eec44d2fedaa
+    parts = zone_id.split('_')
+    if len(parts) == 2 and parts[0] == parts[1]:
+        zone_id = parts[0]
     url = _ARTETV_URL + ARTETV_ENDPOINTS['zonepage'].format(
         lang=lang, client='tv', zone_id=zone_id, country=lang.upper(), page=page_idx)
     return _load_json_full_url('artetv_getzonepage', url, ARTETV_HEADERS)

--- a/plugin.video.arteplussept/resources/lib/mapper/artefavorites.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/artefavorites.py
@@ -12,10 +12,6 @@ from resources.lib.mapper.artecollection import ArteCollection
 class ArteFavorites(ArteCollection):
     """Arte favorites is a kind of user bookmark of arte content managed with Arte TV API."""
 
-    def __init__(self, plugin, settings):
-        super().__init__(plugin, settings)
-        self.auth_token = user.get_cached_token(self.plugin, settings.username)
-
     def build_item(self, label):
         """
         Return menu item to access logged-in user's Arte favorites
@@ -24,39 +20,50 @@ class ArteFavorites(ArteCollection):
 
     def build_menu(self, page):
         """Build the menu for user favorites thanks to API call"""
-        return super()._build_menu(
-            api.get_favorites(self.settings.language, self.auth_token, page),
-            'favorites')
+        menu = None
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            menu = super()._build_menu(
+                api.get_favorites(self.settings.language, auth_token, page),
+                'favorites')
+        return menu
 
     def add_favorite(self, program_id, label):
         """Add content program_id to user favorites.
         Notify about completion success or failure with label."""
-        if 200 == api.add_favorite(self.auth_token, program_id, self.settings.language):
-            msg = self.plugin.addon.getLocalizedString(30025).format(label=label)
-            self.plugin.notify(msg=msg, image='info')
-        else:
-            msg = self.plugin.addon.getLocalizedString(30026).format(label=label)
-            self.plugin.notify(msg=msg, image='error')
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            if 200 == api.add_favorite(auth_token, program_id, self.settings.language):
+                msg = self.plugin.addon.getLocalizedString(30025).format(label=label)
+                self.plugin.notify(msg=msg, image='info')
+            else:
+                msg = self.plugin.addon.getLocalizedString(30026).format(label=label)
+                self.plugin.notify(msg=msg, image='error')
 
     def remove_favorite(self, program_id, label):
         """Remove content program_id from user favorites.
         Notify about completion success or failure with label."""
-        if 200 == api.remove_favorite(self.auth_token, program_id):
-            msg = self.plugin.addon.getLocalizedString(30027).format(label=label)
-            self.plugin.notify(msg=msg, image='info')
-        else:
-            msg = self.plugin.addon.getLocalizedString(30028).format(label=label)
-            self.plugin.notify(msg=msg, image='error')
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            if 200 == api.remove_favorite(auth_token, program_id):
+                msg = self.plugin.addon.getLocalizedString(30027).format(label=label)
+                self.plugin.notify(msg=msg, image='info')
+            else:
+                msg = self.plugin.addon.getLocalizedString(30028).format(label=label)
+                self.plugin.notify(msg=msg, image='error')
 
     def purge(self):
         """Flush user favorites and notify about success or failure"""
-        purge_confirmed = xbmcgui.Dialog().yesno(
-            self.plugin.addon.getLocalizedString(30040),
-            self.plugin.addon.getLocalizedString(30043),
-            autoclose=10000)
-
-        if purge_confirmed:
-            if 200 == api.purge_favorites(self.auth_token):
-                self.plugin.notify(msg=self.plugin.addon.getLocalizedString(30041), image='info')
-            else:
-                self.plugin.notify(msg=self.plugin.addon.getLocalizedString(30042), image='error')
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            purge_confirmed = xbmcgui.Dialog().yesno(
+                self.plugin.addon.getLocalizedString(30040),
+                self.plugin.addon.getLocalizedString(30043),
+                autoclose=10000)
+            if purge_confirmed:
+                if 200 == api.purge_favorites(auth_token):
+                    self.plugin.notify(
+                        msg=self.plugin.addon.getLocalizedString(30041), image='info')
+                else:
+                    self.plugin.notify(
+                        msg=self.plugin.addon.getLocalizedString(30042), image='error')

--- a/plugin.video.arteplussept/resources/lib/mapper/artehistory.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/artehistory.py
@@ -16,10 +16,6 @@ class ArteHistory(ArteCollection):
     It is available with Arte TV APA "last viewed" only.
     """
 
-    def __init__(self, plugin, settings):
-        super().__init__(plugin, settings)
-        self.auth_token = user.get_cached_token(self.plugin, settings.username)
-
     def build_item(self, label):
         """
         Return menu item to access logged-in user's Arte history
@@ -30,19 +26,27 @@ class ArteHistory(ArteCollection):
         """
         Return current page of user's history
         """
-        return super()._build_menu(
-            api.get_last_viewed(self.settings.language, self.auth_token, page),
-            'last_viewed'
-        )
+        menu = None
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            menu = super()._build_menu(
+                api.get_last_viewed(self.settings.language, auth_token, page),
+                'last_viewed'
+            )
+        return menu
 
     def purge(self):
         """Flush user history and notify about success or failure"""
-        purge_confirmed = xbmcgui.Dialog().yesno(
-            self.plugin.addon.getLocalizedString(30030),
-            self.plugin.addon.getLocalizedString(30033),
-            autoclose=10000)
-        if purge_confirmed:
-            if 200 == api.purge_last_viewed(self.auth_token):
-                self.plugin.notify(msg=self.plugin.addon.getLocalizedString(30031), image='info')
-            else:
-                self.plugin.notify(msg=self.plugin.addon.getLocalizedString(30032), image='error')
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            purge_confirmed = xbmcgui.Dialog().yesno(
+                self.plugin.addon.getLocalizedString(30030),
+                self.plugin.addon.getLocalizedString(30033),
+                autoclose=10000)
+            if purge_confirmed:
+                if 200 == api.purge_last_viewed(auth_token):
+                    self.plugin.notify(
+                        msg=self.plugin.addon.getLocalizedString(30031), image='info')
+                else:
+                    self.plugin.notify(
+                        msg=self.plugin.addon.getLocalizedString(30032), image='error')

--- a/plugin.video.arteplussept/resources/lib/user.py
+++ b/plugin.video.arteplussept/resources/lib/user.py
@@ -122,7 +122,9 @@ def is_logged_in_as(plugin):
 def get_cached_token(plugin, token_idx, silent=False):
     """
     Return cached token for identified user or None.
-    If user logged in and later changed the user email, it returns None
+    If no token is in cache and silent is not True, then it warns user
+    about the need to authenticate.
+    If user logged in and later changed the user email, it returns None.
     """
     cached_token = plugin.get_storage(_STORAGE_KEY, TTL=_TTL)
     if token_idx in cached_token and isinstance(cached_token[token_idx], dict):

--- a/plugin.video.arteplussept/resources/lib/view.py
+++ b/plugin.video.arteplussept/resources/lib/view.py
@@ -62,20 +62,17 @@ def mark_as_watched(plugin, usr, program_id, label):
     in order to mark a program as watched
     """
     status = -1
-    try:
-        program_info = api.player_video(stg.languages[0], program_id)
-        total_time = program_info.get('attributes').get('metadata').get('duration').get('seconds')
-        status = api.sync_last_viewed(user.get_cached_token(plugin, usr), program_id, total_time)
-    # pylint: disable=broad-exception-caught
-    except Exception as excp:
-        xbmc.log(f" exception caught :{str(excp)}")
-
-    if 200 == status:
-        msg = plugin.addon.getLocalizedString(30036).format(label=label)
-        plugin.notify(msg=msg, image='info')
-    else:
-        msg = plugin.addon.getLocalizedString(30037).format(label=label)
-        plugin.notify(msg=msg, image='error')
+    program_info = api.player_video(stg.languages[0], program_id)
+    total_time = program_info.get('attributes').get('metadata').get('duration').get('seconds')
+    auth_token = user.get_cached_token(plugin, usr)
+    if auth_token:
+        status = api.sync_last_viewed(auth_token, program_id, total_time)
+        if 200 == status:
+            msg = plugin.addon.getLocalizedString(30036).format(label=label)
+            plugin.notify(msg=msg, image='info')
+        else:
+            msg = plugin.addon.getLocalizedString(30037).format(label=label)
+            plugin.notify(msg=msg, image='error')
 
 
 def build_mixed_collection(plugin, kind, collection_id, settings):


### PR DESCRIPTION
- Fix next page navigation, when zone_id was made of a duplicated uuid separated with a _. Made code compatible with unexpected value returned by Arte TV API.
- Smarter warning notification instead of error and warning messages for non authenticated users. A single warning is displayed, when a user tries to do something requiering auth. Not at start-up and in unconsistent way.