### PR TITLE
feat: Add support for external item, i.e. arte tv page, e.g. section "short movies"

### DIFF
--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -283,10 +283,10 @@ def streams(kind, program_id, lang):
     return _load_json('hbbtv_streams', url).get('videoStreams', [])
 
 
-def page_content(lang):
+def page_content(lang, cat='HOME'):
     """Get content to be display in a page. It can be a page for a category or the home page."""
     url = _ARTETV_URL + ARTETV_ENDPOINTS['page'].format(
-        lang=lang, category='HOME', client='tv')
+        lang=lang, category=cat, client='tv')
     return _load_json_full_url('artetv_home', url, ARTETV_HEADERS)
 
 

--- a/plugin.video.arteplussept/resources/lib/mapper/arteitem.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/arteitem.py
@@ -177,10 +177,30 @@ class ArteTvVideoItem(ArteVideoItem):
         item = self.json_dict
         program_id = item.get('programId')
         kind = self._get_kind()
+
+        path = None
+        is_playable = None
+        additional_context_menu = []
+
         if kind == 'EXTERNAL':
+            deeplink = item.get('deeplink', '')
+            if deeplink is not None and deeplink.strip() != "":
+                category = deeplink.rsplit("/", 1)[-1]
+                path = self.plugin.url_for('raw_page', category=category)
+                is_playable = False
+                return {
+                    'label': item.get('title'),
+                    'path': path,
+                    'thumbnail': self._get_image_url('480x270', True),
+                    'is_playable': is_playable,
+                    'info_type': 'video',
+                    'properties': {
+                        'farnart_image': self._get_image_url('1920x1080', False)
+                    }
+                }
+            # else abort, unable to build an item for an external link
             return None
 
-        additional_context_menu = []
         if self.is_playlist():
             if kind in self.PREFERED_KINDS:
                 # content_type = Content.PLAYLIST

--- a/plugin.video.arteplussept/resources/lib/plugin.py
+++ b/plugin.video.arteplussept/resources/lib/plugin.py
@@ -75,6 +75,15 @@ def display_category_page(zone_id, page, page_id):
     return lst_itms
 
 
+@plugin.route('/raw_page/<category>', name='raw_page')
+def display_raw_page(category):
+    """Display the menu for a category that needs an api call"""
+    lst_itms = view.build_page(plugin, settings, category)
+    xbmc.log(f"all my lst_itms {lst_itms}", xbmc.LOGWARNING)
+    logger.log_xbmc(lst_itms, 'raw_page')
+    return lst_itms
+
+
 @plugin.route('/favorites', name='favorites_default')
 @plugin.route('/favorites/<page>', name='favorites')
 def display_favorites(page=1):

--- a/plugin.video.arteplussept/resources/lib/plugin.py
+++ b/plugin.video.arteplussept/resources/lib/plugin.py
@@ -1,5 +1,6 @@
 """Main module for Kodi add-on plugin.video.arteplussept"""
 
+from datetime import date
 import xbmcaddon
 import xbmcgui
 # pylint: disable=import-error
@@ -18,10 +19,9 @@ from resources.lib.settings import Settings
 from resources.lib import utils
 from resources.lib.utils import PlayFrom
 
-# global declarations
-# plugin stuff
-plugin = Plugin()
+DATE_FORMAT = "%Y-%m-%d"
 
+plugin = Plugin()
 settings = Settings(plugin)
 
 
@@ -34,18 +34,40 @@ def display_index():
     addon = xbmcaddon.Addon()
     current_version = addon.getAddonInfo("version")
     last_version = addon.getSetting("last_version_notified")
+    last_date = addon.getSetting("last_date_notified")
 
-    if last_version != current_version:
+    if last_version != current_version or days_since(last_date) >= 30:
         xbmcgui.Dialog().ok(
             addon.getLocalizedString(30061).format(version=current_version),
             addon.getLocalizedString(30062).format(version=current_version)
         )
-        addon.setSetting("last_info_version", current_version)
+        addon.setSetting("last_version_notified", current_version)
+        addon.setSetting("last_date_notified", date.today().strftime(DATE_FORMAT))
 
     lst_itms = view.build_home_page(
         plugin, settings, plugin.get_storage('cached_categories', TTL=60))
     logger.log_xbmc(lst_itms, 'index')
     return lst_itms
+
+
+def days_since(date_str):
+    """
+    date_str: '2026-08-14' or '' (empty)
+    Returns number of days between today and date_str.
+    If empty → MAX_INT.
+    """
+
+    if not date_str:
+        return 1000000
+
+    try:
+        other = date.fromisoformat(date_str)
+    except ValueError:
+        # invalid format, not a date
+        return 1000000
+
+    today = date.today()
+    return (today - other).days
 
 
 @plugin.route('/category/api/<category_code>', name='api_category')

--- a/plugin.video.arteplussept/resources/lib/view.py
+++ b/plugin.video.arteplussept/resources/lib/view.py
@@ -5,6 +5,7 @@ from xbmcswift2 import xbmc
 from resources.lib.mapper.arteitem import ArteItem
 from resources.lib.mapper.arteliveitem import ArteLiveItem
 from resources.lib.mapper.artesearch import ArteSearch
+from resources.lib.mapper.artezone import ArteZone
 from resources.lib import api
 from resources.lib import hof
 from resources.lib.mapper import mapper
@@ -42,6 +43,23 @@ def build_home_page(plugin, settings, cached_categories):
                  level=xbmc.LOGERROR)
 
     return addon_menu
+
+
+def build_page(plugin, settings, category):
+    """
+    Build a page for a category like SER, CIN, DOR...
+    A page is a list of zones.
+    To be extended to HOME.
+    """
+    page = api.page_content(settings.language, category)
+    page_menu = []
+    for zone in page.get('zones', []):
+        page_item = ArteZone(
+            plugin, settings, plugin.get_storage('cached_categories', TTL=60)
+        ).build_item(zone)
+        if page_item:
+            page_menu.append(page_item)
+    return page_menu
 
 
 def build_api_category(plugin, category_code, settings):

--- a/plugin.video.arteplussept/resources/settings.xml
+++ b/plugin.video.arteplussept/resources/settings.xml
@@ -25,6 +25,16 @@
 			label="30056"
 			values="DEFAULT|API|DISPLAY|API+DISPLAY"
 			default="0"/>
+		<setting
+			id="last_version_notified"
+			type="text"
+			default=""
+			visible="false" />
+		<setting
+			id="last_date_notified"
+			type="text"
+			default=""
+			visible="false" />
 	</category>
 	
 	<!-- Profile -->


### PR DESCRIPTION
- similar to HOME page, but for content like Cinema, Series, Documentaires, Concerts...
- page is a list of zones.
- request from issue #74
