### PR TITLE
fix: refresh the cache when a cached category expired

### DIFF
--- a/plugin.video.arteplussept/resources/lib/mapper/artezone.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/artezone.py
@@ -3,6 +3,7 @@ Module for Arte Zone
 """
 
 # pylint: disable=import-error
+from xbmcswift2 import xbmc
 from resources.lib import api
 from resources.lib.mapper.artecollection import ArteCollection
 
@@ -32,6 +33,23 @@ class ArteZone(ArteCollection):
                 'path': self.plugin.url_for('cached_category', zone_id=zone_id)
             }
         return None
+
+    def get_cached_item(self, zone_id):
+        """
+        Return the content of the zone zone_id, that was cached while building a page.
+        The cache is only populated while building a page and its entries expire,
+        so refresh it with an API call, when the entry expired or was never cached.
+        """
+        try:
+            return self.cached_categories[zone_id]
+        except KeyError:
+            xbmc.log(
+                f"No cached content for zone {zone_id}. Refreshing the cache with an API call.",
+                level=xbmc.LOGINFO)
+            cached_category = self.build_menu(zone_id, 1, 'HOME')
+            if self._is_valid_menu(cached_category):
+                self.cached_categories[zone_id] = cached_category
+            return cached_category
 
     def _is_valid_menu(self, cached_category):
         """

--- a/plugin.video.arteplussept/resources/lib/plugin.py
+++ b/plugin.video.arteplussept/resources/lib/plugin.py
@@ -83,7 +83,7 @@ def display_cached_category(zone_id):
     """Display the menu for a category that is stored
     in cache from previous api call like home page"""
     lst_itms = view.get_cached_category(
-        zone_id, plugin.get_storage('cached_categories', TTL=60))
+        plugin, settings, zone_id, plugin.get_storage('cached_categories', TTL=60))
     logger.log_xbmc(lst_itms, 'cached_category')
     return lst_itms
 

--- a/plugin.video.arteplussept/resources/lib/view.py
+++ b/plugin.video.arteplussept/resources/lib/view.py
@@ -70,10 +70,11 @@ def build_api_category(plugin, category_code, settings):
     return category
 
 
-def get_cached_category(zone_id, cached_categories):
+def get_cached_category(plugin, settings, zone_id, cached_categories):
     """Return the menu for a category that is stored
-    in cache from previous api call like home page"""
-    return cached_categories[zone_id]
+    in cache from previous api call like home page.
+    The cache is refreshed with an API call, when the entry expired or was never cached."""
+    return ArteZone(plugin, settings, cached_categories).get_cached_item(zone_id)
 
 
 def mark_as_watched(plugin, usr, program_id, label):


### PR DESCRIPTION
cached_categories is only filled while building a page and expires after 60 minutes, so opening a category from a page Kodi still displays raises a KeyError. Let ArteZone, which already owns the cache, refetch and re-cache the zone instead of failing.